### PR TITLE
Sync local HealthClaw updates for device demo and phone flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,15 @@ when dinner time hits, it does not stop at one suggestion—it searches delivery
 
 <p align="center">
   <video
-    poster="./docs/readme_media/one_click_health_demo_cover_en.png"
-    src="https://github.com/user-attachments/assets/06e6d9fa-b3f1-4542-93c7-be3b91b7aca3"
+    poster="./docs/readme_media/one_click_health_demo_cover.png"
+    src="https://github.com/user-attachments/assets/a3ae7af3-3176-475c-90a9-2dfc97c30a81"
     controls
     muted
     playsinline
     preload="metadata"
     width="800"
   >
-    If the player does not appear, <a href="https://github.com/user-attachments/assets/06e6d9fa-b3f1-4542-93c7-be3b91b7aca3">open the video directly</a>.
+    If the player does not appear, <a href="https://github.com/user-attachments/assets/a3ae7af3-3176-475c-90a9-2dfc97c30a81">open the video directly</a>.
   </video>
 </p>
 
@@ -87,15 +87,15 @@ it reads device-side data in order and produces one consolidated report—scores
 
 <p align="center">
   <video
-    poster="./docs/readme_media/showcase_risk_prediction_cover_en.png"
-    src="https://github.com/user-attachments/assets/2bd61616-43d1-4a54-a4b6-7acfa6a43394"
+    poster="./docs/readme_media/showcase_risk_prediction_cover.png"
+    src="https://github.com/user-attachments/assets/f096dd86-905e-451d-a577-b1d4e5613ebc"
     controls
     muted
     playsinline
     preload="metadata"
     width="800"
   >
-    If the player does not appear, <a href="https://github.com/user-attachments/assets/2bd61616-43d1-4a54-a4b6-7acfa6a43394">open the video directly</a>.
+    If the player does not appear, <a href="https://github.com/user-attachments/assets/f096dd86-905e-451d-a577-b1d4e5613ebc">open the video directly</a>.
   </video>
 </p>
 

--- a/assets/ukb_tools_schema.json
+++ b/assets/ukb_tools_schema.json
@@ -162,7 +162,7 @@
     "name": "phone_control",
     "description": "控制通过ADB连接的Android手机。支持截图、点击、滑动、输入文字、获取UI元素、启动App等操作。可用于操控手机App（如点外卖、查看健康数据等）。每次操作后建议用ui_dump或screenshot确认结果。cost=0.02。使用前需先check_connection确认手机已连接。",
     "parameters": {"type": "object", "properties": {
-      "action": {"type": "string", "enum": ["check_connection", "screenshot", "tap", "swipe", "input_text", "press_key", "launch_app", "ui_dump", "tap_keyword_confirm", "scroll_down", "scroll_up", "current_app", "list_apps"], "description": "要执行的操作类型"},
+      "action": {"type": "string", "enum": ["check_connection", "screenshot", "tap", "swipe", "input_text", "press_key", "launch_app", "ui_dump", "scroll_down", "scroll_up", "current_app", "list_apps"], "description": "要执行的操作类型"},
       "x": {"type": "number", "description": "点击/滑动起点的x坐标（像素）"},
       "y": {"type": "number", "description": "点击/滑动起点的y坐标（像素）"},
       "x2": {"type": "number", "description": "滑动终点的x坐标"},
@@ -171,9 +171,7 @@
       "key": {"type": "string", "description": "要按的键: back/home/recent/enter/delete"},
       "app": {"type": "string", "description": "要启动的App名称(如'美团外卖','微信')或包名"},
       "keyword": {"type": "string", "description": "ui_dump时过滤含该关键词的元素"},
-      "clickable_only": {"type": "boolean", "description": "ui_dump时是否只显示可点击元素；tap_keyword_confirm也可用该参数优先可点击节点", "default": false},
-      "confirm_keyword": {"type": "string", "description": "tap_keyword_confirm 的可选确认关键词（点击后会检查该关键词是否出现）"},
-      "wait_ms": {"type": "number", "description": "tap_keyword_confirm 点击后等待毫秒数，默认1200"}
+      "clickable_only": {"type": "boolean", "description": "ui_dump时是否只显示可点击元素", "default": false}
     }, "required": ["action"]}
   }},
   {"type": "function", "function": {

--- a/cross_device_node.py
+++ b/cross_device_node.py
@@ -17,44 +17,68 @@ DEFAULT_BINDINGS_PATH = "memory/device_bindings.json"
 DEMO_LOCATION_PRESETS = {
     "heart_rate_spike": {
         "location_text": "复旦大学邯郸校区 6 号楼 203 室",
+        "location_text_en": "Room 203, Building 6, Handan Campus, Fudan University",
         "campus": "复旦大学邯郸校区",
+        "campus_en": "Handan Campus, Fudan University",
         "building": "6 号楼",
+        "building_en": "Building 6",
         "room": "203 室",
+        "room_en": "Room 203",
         "source": "demo_simulated_wearable_location",
     },
     "low_oxygen": {
         "location_text": "复旦大学邯郸校区 5 号楼 305 室",
+        "location_text_en": "Room 305, Building 5, Handan Campus, Fudan University",
         "campus": "复旦大学邯郸校区",
+        "campus_en": "Handan Campus, Fudan University",
         "building": "5 号楼",
+        "building_en": "Building 5",
         "room": "305 室",
+        "room_en": "Room 305",
         "source": "demo_simulated_wearable_location",
     },
     "fall_detected": {
         "location_text": "复旦大学邯郸校区 2 号楼 102 室门口走廊",
+        "location_text_en": "Hallway outside Room 102, Building 2, Handan Campus, Fudan University",
         "campus": "复旦大学邯郸校区",
+        "campus_en": "Handan Campus, Fudan University",
         "building": "2 号楼",
+        "building_en": "Building 2",
         "room": "102 室门口",
+        "room_en": "Outside Room 102",
         "source": "demo_simulated_wearable_location",
     },
     "irregular_rhythm": {
         "location_text": "复旦大学邯郸校区 4 号楼 301 室",
+        "location_text_en": "Room 301, Building 4, Handan Campus, Fudan University",
         "campus": "复旦大学邯郸校区",
+        "campus_en": "Handan Campus, Fudan University",
         "building": "4 号楼",
+        "building_en": "Building 4",
         "room": "301 室",
+        "room_en": "Room 301",
         "source": "demo_simulated_wearable_location",
     },
     "high_temperature": {
         "location_text": "复旦大学邯郸校区 7 号楼 318 室",
+        "location_text_en": "Room 318, Building 7, Handan Campus, Fudan University",
         "campus": "复旦大学邯郸校区",
+        "campus_en": "Handan Campus, Fudan University",
         "building": "7 号楼",
+        "building_en": "Building 7",
         "room": "318 室",
+        "room_en": "Room 318",
         "source": "demo_simulated_wearable_location",
     },
     "prolonged_inactivity": {
         "location_text": "复旦大学邯郸校区 8 号楼 206 室",
+        "location_text_en": "Room 206, Building 8, Handan Campus, Fudan University",
         "campus": "复旦大学邯郸校区",
+        "campus_en": "Handan Campus, Fudan University",
         "building": "8 号楼",
+        "building_en": "Building 8",
         "room": "206 室",
+        "room_en": "Room 206",
         "source": "demo_simulated_wearable_location",
     },
 }
@@ -63,7 +87,9 @@ DEMO_LOCATION_PRESETS = {
 DEMO_SIGNAL_SCENARIOS = {
     "heart_rate_spike": {
         "label": "心率持续过快",
+        "label_en": "Sustained high heart rate",
         "description": "",
+        "description_en": "",
         "alert_payload": {
             "signal_type": "heart_rate",
             "heart_rate": 145,
@@ -85,7 +111,9 @@ DEMO_SIGNAL_SCENARIOS = {
     },
     "low_oxygen": {
         "label": "血氧持续偏低",
+        "label_en": "Sustained low oxygen",
         "description": "模拟可穿戴设备检测到血氧持续低于安全阈值。",
+        "description_en": "Simulates a wearable device reporting oxygen saturation below the safety threshold for a sustained period.",
         "alert_payload": {
             "signal_type": "blood_oxygen",
             "spo2": 88,
@@ -105,7 +133,9 @@ DEMO_SIGNAL_SCENARIOS = {
     },
     "fall_detected": {
         "label": "疑似跌倒",
+        "label_en": "Possible fall detected",
         "description": "模拟手表/胸牌检测到跌倒冲击并且老人短时间内没有恢复活动。",
+        "description_en": "Simulates a watch or badge detecting a fall impact and no meaningful movement shortly afterward.",
         "alert_payload": {
             "signal_type": "fall_detected",
             "fall_detected": True,
@@ -125,7 +155,9 @@ DEMO_SIGNAL_SCENARIOS = {
     },
     "irregular_rhythm": {
         "label": "疑似心律不齐",
+        "label_en": "Possible irregular rhythm",
         "description": "模拟可穿戴 ECG 或脉搏节律算法提示可能存在心律不齐。",
+        "description_en": "Simulates a wearable ECG or pulse rhythm algorithm flagging a possible irregular rhythm.",
         "alert_payload": {
             "signal_type": "irregular_rhythm",
             "irregular_rhythm_detected": True,
@@ -147,7 +179,9 @@ DEMO_SIGNAL_SCENARIOS = {
     },
     "high_temperature": {
         "label": "体温异常升高",
+        "label_en": "Abnormally high temperature",
         "description": "模拟可穿戴体温传感器提示持续发热。",
+        "description_en": "Simulates a wearable temperature sensor reporting sustained fever.",
         "alert_payload": {
             "signal_type": "body_temperature",
             "body_temperature": 39.1,
@@ -169,7 +203,9 @@ DEMO_SIGNAL_SCENARIOS = {
     },
     "prolonged_inactivity": {
         "label": "长时间无活动",
+        "label_en": "Prolonged inactivity",
         "description": "模拟老人佩戴设备连续数小时无明显活动。",
+        "description_en": "Simulates several hours of minimal movement detected by the wearable.",
         "alert_payload": {
             "signal_type": "inactivity",
             "inactivity_minutes": 180,
@@ -190,16 +226,107 @@ DEMO_SIGNAL_SCENARIOS = {
 }
 
 
+def _normalize_demo_locale(locale):
+    return "en" if str(locale or "").strip().lower().startswith("en") else "zh"
+
+
+def _localized_demo_location(location, locale):
+    loc = _normalize_demo_locale(locale)
+    if loc != "en":
+        return {
+            "location_text": location.get("location_text", ""),
+            "campus": location.get("campus", ""),
+            "building": location.get("building", ""),
+            "room": location.get("room", ""),
+            "source": location.get("source", ""),
+        }
+    return {
+        "location_text": location.get("location_text_en") or location.get("location_text", ""),
+        "campus": location.get("campus_en") or location.get("campus", ""),
+        "building": location.get("building_en") or location.get("building", ""),
+        "room": location.get("room_en") or location.get("room", ""),
+        "source": location.get("source", ""),
+    }
+
+
+def _build_demo_signal_message(scenario_key, payload, safe, locale):
+    loc = _normalize_demo_locale(locale)
+    if loc != "en":
+        return ""
+    if scenario_key == "heart_rate_spike":
+        if safe:
+            return (
+                f"Current heart rate is {payload.get('heart_rate', 0)} bpm for {payload.get('duration_sec', 0)}s, "
+                "which is still below the alert threshold."
+            )
+        return (
+            f"Sustained high heart rate detected ({payload.get('heart_rate', 0)} bpm for {payload.get('duration_sec', 0)}s). "
+            "Please check on the older adult soon."
+        )
+    if scenario_key == "low_oxygen":
+        if safe:
+            return (
+                f"Current oxygen saturation is {payload.get('spo2', 0)}% for {payload.get('duration_sec', 0)}s, "
+                "which is still within the safe range."
+            )
+        return (
+            f"Sustained low oxygen detected (SpO2 {payload.get('spo2', 0)}% for {payload.get('duration_sec', 0)}s). "
+            "Please confirm breathing status as soon as possible."
+        )
+    if scenario_key == "fall_detected":
+        if safe:
+            return "No reportable fall event is currently detected."
+        return (
+            f"Possible fall detected ({payload.get('impact_g', 0.0):.1f}g impact, {payload.get('no_movement_sec', 0)}s without movement). "
+            "Please verify whether the older adult is injured immediately."
+        )
+    if scenario_key == "irregular_rhythm":
+        if safe:
+            return "No sustained abnormal rhythm has been detected so far."
+        return (
+            f"Possible irregular rhythm detected for {payload.get('duration_sec', 0)}s with {payload.get('episode_count', 0)} flagged segments. "
+            "Please check on the older adult soon."
+        )
+    if scenario_key == "high_temperature":
+        if safe:
+            return (
+                f"Current temperature is about {payload.get('body_temperature', 0.0):.1f}C for {payload.get('duration_sec', 0)}s, "
+                "which has not reached the alert rule."
+            )
+        return (
+            f"Abnormally high temperature detected ({payload.get('body_temperature', 0.0):.1f}C for {payload.get('duration_sec', 0)}s). "
+            "Please confirm the older adult's condition promptly."
+        )
+    if scenario_key == "prolonged_inactivity":
+        if safe:
+            return (
+                f"Current inactivity duration is {payload.get('inactivity_minutes', 0)} minutes, "
+                "which is still below the alert threshold."
+            )
+        return (
+            f"Prolonged inactivity detected ({payload.get('inactivity_minutes', 0)} minutes without meaningful movement). "
+            "Please check whether the older adult is safe."
+        )
+    return ""
+
+
 def get_demo_signal_scenarios():
     return copy.deepcopy(DEMO_SIGNAL_SCENARIOS)
 
 
-def build_demo_signal_payload(scenario_key, sender_id="elder_01", safe=False):
+def build_demo_signal_payload(scenario_key, sender_id="elder_01", safe=False, locale="zh"):
     scenarios = get_demo_signal_scenarios()
     if scenario_key not in scenarios:
         raise KeyError(f"unknown demo scenario: {scenario_key}")
     payload_key = "safe_payload" if safe else "alert_payload"
-    payload = scenarios[scenario_key][payload_key]
+    payload = copy.deepcopy(scenarios[scenario_key][payload_key])
+    payload["locale"] = _normalize_demo_locale(locale)
+    location = payload.get("location")
+    if isinstance(location, dict):
+        payload["location"] = _localized_demo_location(location, locale)
+    message = _build_demo_signal_message(scenario_key, payload, safe, locale)
+    if message:
+        payload["message"] = message
     payload["sender_id"] = sender_id
     return payload
 
@@ -281,11 +408,12 @@ def _base_context(payload):
     sender_id = str(payload.get("sender_id", "") or "")
     severity = str(payload.get("severity", "") or "")
     timestamp = str(payload.get("timestamp", "") or time.strftime("%Y-%m-%d %H:%M:%S"))
-    return signal_type, sender_id, severity, timestamp
+    locale = _normalize_demo_locale(payload.get("locale", "zh"))
+    return signal_type, sender_id, severity, timestamp, locale
 
 
 def _evaluate_heart_rate(payload):
-    signal_type, sender_id, severity, timestamp = _base_context(payload)
+    signal_type, sender_id, severity, timestamp, locale = _base_context(payload)
     heart_rate = _coerce_int(payload.get("heart_rate", payload.get("value", 0)), 0)
     duration_sec = _coerce_int(payload.get("duration_sec", 0), 0)
     threshold = _coerce_int(payload.get("threshold", 130), 130)
@@ -305,6 +433,7 @@ def _evaluate_heart_rate(payload):
         "signal_type": signal_type,
         "sender_id": sender_id,
         "timestamp": timestamp,
+        "locale": locale,
         "heart_rate": heart_rate,
         "duration_sec": duration_sec,
         "threshold": threshold,
@@ -328,7 +457,7 @@ def _evaluate_heart_rate(payload):
 
 
 def _evaluate_blood_oxygen(payload):
-    signal_type, sender_id, severity, timestamp = _base_context(payload)
+    signal_type, sender_id, severity, timestamp, locale = _base_context(payload)
     spo2 = _coerce_int(payload.get("spo2", payload.get("value", 0)), 0)
     duration_sec = _coerce_int(payload.get("duration_sec", 0), 0)
     low_threshold = _coerce_int(payload.get("low_threshold", 90), 90)
@@ -347,6 +476,7 @@ def _evaluate_blood_oxygen(payload):
         "signal_type": signal_type,
         "sender_id": sender_id,
         "timestamp": timestamp,
+        "locale": locale,
         "spo2": spo2,
         "duration_sec": duration_sec,
         "low_threshold": low_threshold,
@@ -369,7 +499,7 @@ def _evaluate_blood_oxygen(payload):
 
 
 def _evaluate_fall_detected(payload):
-    signal_type, sender_id, severity, timestamp = _base_context(payload)
+    signal_type, sender_id, severity, timestamp, locale = _base_context(payload)
     fall_detected = _coerce_bool(payload.get("fall_detected", payload.get("value", False)), False)
     impact_g = _coerce_float(payload.get("impact_g", 0.0), 0.0)
     no_movement_sec = _coerce_int(payload.get("no_movement_sec", 0), 0)
@@ -387,6 +517,7 @@ def _evaluate_fall_detected(payload):
         "signal_type": signal_type,
         "sender_id": sender_id,
         "timestamp": timestamp,
+        "locale": locale,
         "fall_detected": fall_detected,
         "impact_g": impact_g,
         "no_movement_sec": no_movement_sec,
@@ -407,7 +538,7 @@ def _evaluate_fall_detected(payload):
 
 
 def _evaluate_irregular_rhythm(payload):
-    signal_type, sender_id, severity, timestamp = _base_context(payload)
+    signal_type, sender_id, severity, timestamp, locale = _base_context(payload)
     detected = _coerce_bool(payload.get("irregular_rhythm_detected", payload.get("value", False)), False)
     duration_sec = _coerce_int(payload.get("duration_sec", 0), 0)
     min_duration_sec = _coerce_int(payload.get("min_duration_sec", 45), 45)
@@ -426,6 +557,7 @@ def _evaluate_irregular_rhythm(payload):
         "signal_type": signal_type,
         "sender_id": sender_id,
         "timestamp": timestamp,
+        "locale": locale,
         "irregular_rhythm_detected": detected,
         "duration_sec": duration_sec,
         "min_duration_sec": min_duration_sec,
@@ -450,7 +582,7 @@ def _evaluate_irregular_rhythm(payload):
 
 
 def _evaluate_body_temperature(payload):
-    signal_type, sender_id, severity, timestamp = _base_context(payload)
+    signal_type, sender_id, severity, timestamp, locale = _base_context(payload)
     body_temperature = _coerce_float(
         payload.get("body_temperature", payload.get("temperature", payload.get("value", 0.0))),
         0.0,
@@ -492,6 +624,7 @@ def _evaluate_body_temperature(payload):
         "signal_type": signal_type,
         "sender_id": sender_id,
         "timestamp": timestamp,
+        "locale": locale,
         "body_temperature": body_temperature,
         "duration_sec": duration_sec,
         "high_threshold": high_threshold,
@@ -517,7 +650,7 @@ def _evaluate_body_temperature(payload):
 
 
 def _evaluate_inactivity(payload):
-    signal_type, sender_id, severity, timestamp = _base_context(payload)
+    signal_type, sender_id, severity, timestamp, locale = _base_context(payload)
     inactivity_minutes = _coerce_int(payload.get("inactivity_minutes", payload.get("minutes", 0)), 0)
     threshold_minutes = _coerce_int(payload.get("threshold_minutes", 120), 120)
     during_sleep = _coerce_bool(payload.get("during_sleep", False), False)
@@ -537,6 +670,7 @@ def _evaluate_inactivity(payload):
         "signal_type": signal_type,
         "sender_id": sender_id,
         "timestamp": timestamp,
+        "locale": locale,
         "inactivity_minutes": inactivity_minutes,
         "threshold_minutes": threshold_minutes,
         "during_sleep": during_sleep,
@@ -720,6 +854,7 @@ def build_alert_requests(
     severity="warning",
     details=None,
     timestamp="",
+    locale="",
     target_ids=None,
     binding_file=DEFAULT_BINDINGS_PATH,
 ):
@@ -744,6 +879,8 @@ def build_alert_requests(
             "severity": severity or "warning",
             "timestamp": timestamp or time.strftime("%Y-%m-%d %H:%M:%S"),
         }
+        if locale:
+            payload["locale"] = locale
         if details:
             payload["details"] = details
         if node.get("recipient_open_id"):
@@ -766,6 +903,7 @@ def send_bound_alert(
     severity="warning",
     details=None,
     timestamp="",
+    locale="",
     target_ids=None,
     binding_file=DEFAULT_BINDINGS_PATH,
     timeout=10,
@@ -777,6 +915,7 @@ def send_bound_alert(
         severity=severity,
         details=details or {},
         timestamp=timestamp,
+        locale=locale,
         target_ids=target_ids,
         binding_file=binding_file,
     )
@@ -1014,6 +1153,7 @@ class CrossDeviceServer:
                             severity=decision["severity"],
                             details=decision.get("details", {}),
                             timestamp=decision.get("timestamp", ""),
+                            locale=decision.get("locale", ""),
                             binding_file=outer.binding_file,
                             timeout=10,
                         )

--- a/demo/cross_device_demo_app.py
+++ b/demo/cross_device_demo_app.py
@@ -58,6 +58,79 @@ YOUNG_BASE = "http://127.0.0.1:8787"
 ELDER_BASE = "http://127.0.0.1:8790"
 DEMO_SIGNAL_SCENARIOS = get_demo_signal_scenarios()
 
+UI_TEXT = {
+    "zh": {
+        "title": "HealthClaw跨设备演示",
+        "section_start": "1. 节点启动",
+        "start_young": "启动年轻人节点",
+        "start_elder": "启动老人节点",
+        "start_both": "一键启动两个节点",
+        "stop_both": "停止两个节点",
+        "reset_demo": "重置演示环境",
+        "young_health": "**年轻人节点健康状态**",
+        "elder_health": "**老人节点健康状态**",
+        "section_binding": "2. 绑定关系",
+        "binding_desc": "默认将老人节点 `elder_01` 与年轻人节点 `child_01` 建立通知关系。",
+        "bind_default": "建立默认绑定",
+        "refresh_bindings": "刷新绑定状态",
+        "current_bindings": "**当前绑定**",
+        "binding_read_error": "当前无法读取绑定: {error}",
+        "section_signal": "3. 模拟可穿戴异常信号",
+        "choose_scenario": "选择异常场景",
+        "sim_location": "模拟位置",
+        "sim_location_help": "演示版先手动模拟位置，后续可以直接替换为真实可穿戴设备上报的位置。",
+        "location_caption": "当前位置为演示定位字段，未来可直接替换为真实智能可穿戴设备上报的位置。",
+        "send_alert": "发送当前异常场景",
+        "send_safe": "发送当前正常样本",
+        "alert_payload": "**异常样本 payload**",
+        "safe_payload": "**正常样本 payload**",
+        "last_result": "**最近一次信号处理结果**",
+        "young_log": "年轻人节点日志",
+        "elder_log": "老人节点日志",
+        "young_start_result": "年轻人节点启动结果: {value}",
+        "elder_start_result": "老人节点启动结果: {value}",
+        "bind_result": "绑定结果: {value}",
+        "stop_result": "停止结果: {value}",
+        "reset_result": "重置结果: {value}",
+        "not_triggered": "not_triggered",
+    },
+    "en": {
+        "title": "HealthClaw Cross-device Demo",
+        "section_start": "1. Start Nodes",
+        "start_young": "Start young-side node",
+        "start_elder": "Start elder-side node",
+        "start_both": "Start both nodes",
+        "stop_both": "Stop both nodes",
+        "reset_demo": "Reset demo environment",
+        "young_health": "**Young-side node health**",
+        "elder_health": "**Elder-side node health**",
+        "section_binding": "2. Device Binding",
+        "binding_desc": "By default, this demo binds elder node `elder_01` to young-side node `child_01` for caregiver notifications.",
+        "bind_default": "Create default binding",
+        "refresh_bindings": "Refresh binding status",
+        "current_bindings": "**Current bindings**",
+        "binding_read_error": "Unable to read current bindings: {error}",
+        "section_signal": "3. Simulate Wearable Alerts",
+        "choose_scenario": "Choose alert scenario",
+        "sim_location": "Simulated location",
+        "sim_location_help": "This demo uses a manual location override for now and can later be replaced with a real wearable-reported location.",
+        "location_caption": "The location shown here is a demo field and can later be replaced by a real wearable-reported location.",
+        "send_alert": "Send alert sample",
+        "send_safe": "Send safe sample",
+        "alert_payload": "**Alert sample payload**",
+        "safe_payload": "**Safe sample payload**",
+        "last_result": "**Most recent signal result**",
+        "young_log": "Young-side node log",
+        "elder_log": "Elder-side node log",
+        "young_start_result": "Young-side node start result: {value}",
+        "elder_start_result": "Elder-side node start result: {value}",
+        "bind_result": "Binding result: {value}",
+        "stop_result": "Stop result: {value}",
+        "reset_result": "Reset result: {value}",
+        "not_triggered": "not_triggered",
+    },
+}
+
 
 def _load_optional_mykey_module():
     try:
@@ -188,13 +261,17 @@ def reset_demo_environment(stop_nodes=False):
     }
 
 
-def launch_process(cmd, log_path, pid_path):
+def launch_process(cmd, log_path, pid_path, env_overrides=None):
     with open(log_path, "ab") as log_file:
+        env = dict(os.environ)
+        if env_overrides:
+            env.update({str(k): str(v) for k, v in env_overrides.items()})
         proc = subprocess.Popen(
             cmd,
             cwd=str(PROJECT_ROOT),
             stdout=log_file,
             stderr=subprocess.STDOUT,
+            env=env,
         )
     pid_path.write_text(str(proc.pid), encoding="utf-8")
     return proc.pid
@@ -207,11 +284,16 @@ def safe_get_json(url):
         return {"status": "down", "msg": str(e)}
 
 
-def start_young_node():
+def start_young_node(locale="zh"):
     health = safe_get_json(YOUNG_BASE + "/healthz")
     if health.get("status") == "ok":
         return {"status": "already_running", "health": health}
-    pid = launch_process([sys.executable, "fsapp.py"], YOUNG_LOG, YOUNG_PID)
+    pid = launch_process(
+        [sys.executable, "fsapp.py"],
+        YOUNG_LOG,
+        YOUNG_PID,
+        env_overrides={"HEALTHCLAW_DEMO_LOCALE": locale},
+    )
     time.sleep(3)
     return {"status": "started", "pid": pid, "health": safe_get_json(YOUNG_BASE + "/healthz")}
 
@@ -277,75 +359,93 @@ def read_log_tail(path, lines=30):
     return "\n".join(text[-lines:])
 
 
-st.set_page_config(page_title="HealthClaw跨设备演示", layout="wide")
-st.title("HealthClaw跨设备演示")
+st.set_page_config(page_title="HealthClaw Cross-device Demo", layout="wide")
 
 ensure_demo_binding_file()
+
+if "cross_demo_locale" not in st.session_state:
+    st.session_state["cross_demo_locale"] = "zh"
+
+locale = st.selectbox(
+    "Language / 语言",
+    ["zh", "en"],
+    index=0 if st.session_state.get("cross_demo_locale", "zh") == "zh" else 1,
+    format_func=lambda value: "中文" if value == "zh" else "English",
+)
+st.session_state["cross_demo_locale"] = locale
+
+
+def t(key, **kwargs):
+    text = UI_TEXT[locale][key]
+    return text.format(**kwargs) if kwargs else text
+
+
+st.title(t("title"))
 
 col1, col2, col3 = st.columns(3)
 
 with col1:
-    st.subheader("1. 节点启动")
-    if st.button("启动年轻人节点", use_container_width=True):
-        st.session_state["young_start"] = start_young_node()
-    if st.button("启动老人节点", use_container_width=True):
+    st.subheader(t("section_start"))
+    if st.button(t("start_young"), use_container_width=True):
+        st.session_state["young_start"] = start_young_node(locale=locale)
+    if st.button(t("start_elder"), use_container_width=True):
         st.session_state["elder_start"] = start_elder_node()
-    if st.button("一键启动两个节点", type="primary", use_container_width=True):
+    if st.button(t("start_both"), type="primary", use_container_width=True):
         st.session_state["reset_result"] = reset_demo_environment(stop_nodes=True)
-        st.session_state["young_start"] = start_young_node()
+        st.session_state["young_start"] = start_young_node(locale=locale)
         st.session_state["elder_start"] = start_elder_node()
-    if st.button("停止两个节点", use_container_width=True):
+    if st.button(t("stop_both"), use_container_width=True):
         young_stopped = stop_process(YOUNG_PID)
         elder_stopped = stop_process(ELDER_PID)
         st.session_state["stop_result"] = {
             "young_stopped": young_stopped,
             "elder_stopped": elder_stopped,
         }
-    if st.button("重置演示环境", use_container_width=True):
+    if st.button(t("reset_demo"), use_container_width=True):
         st.session_state["reset_result"] = reset_demo_environment(stop_nodes=False)
 
-    st.markdown("**年轻人节点健康状态**")
+    st.markdown(t("young_health"))
     st.json(safe_get_json(YOUNG_BASE + "/healthz"))
-    st.markdown("**老人节点健康状态**")
+    st.markdown(t("elder_health"))
     st.json(safe_get_json(ELDER_BASE + "/healthz"))
 
 with col2:
-    st.subheader("2. 绑定关系")
-    st.write("默认将老人节点 `elder_01` 与年轻人节点 `child_01` 建立通知关系。")
-    if st.button("建立默认绑定", use_container_width=True):
+    st.subheader(t("section_binding"))
+    st.write(t("binding_desc"))
+    if st.button(t("bind_default"), use_container_width=True):
         try:
             st.session_state["bind_result"] = bind_demo_nodes()
         except Exception as e:
             st.session_state["bind_result"] = {"status": "error", "msg": str(e)}
-    if st.button("刷新绑定状态", use_container_width=True):
+    if st.button(t("refresh_bindings"), use_container_width=True):
         try:
             st.session_state["bindings"] = get_bindings()
         except Exception as e:
             st.session_state["bindings"] = {"status": "error", "msg": str(e)}
 
-    st.markdown("**当前绑定**")
+    st.markdown(t("current_bindings"))
     try:
         st.json(get_bindings())
     except Exception as e:
-        st.warning(f"当前无法读取绑定: {e}")
+        st.warning(t("binding_read_error", error=e))
 
 with col3:
-    st.subheader("3. 模拟可穿戴异常信号")
+    st.subheader(t("section_signal"))
     scenario_keys = list(DEMO_SIGNAL_SCENARIOS.keys())
     scenario_key = st.selectbox(
-        "选择异常场景",
+        t("choose_scenario"),
         scenario_keys,
-        format_func=lambda key: DEMO_SIGNAL_SCENARIOS[key]["label"],
+        format_func=lambda key: DEMO_SIGNAL_SCENARIOS[key]["label_en"] if locale == "en" else DEMO_SIGNAL_SCENARIOS[key]["label"],
     )
     scenario = DEMO_SIGNAL_SCENARIOS[scenario_key]
-    alert_payload = build_demo_signal_payload(scenario_key, sender_id="elder_01", safe=False)
-    safe_payload = build_demo_signal_payload(scenario_key, sender_id="elder_01", safe=True)
+    alert_payload = build_demo_signal_payload(scenario_key, sender_id="elder_01", safe=False, locale=locale)
+    safe_payload = build_demo_signal_payload(scenario_key, sender_id="elder_01", safe=True, locale=locale)
     default_location_text = ((alert_payload.get("location") or {}).get("location_text") or "").strip()
     location_text = st.text_input(
-        "模拟位置",
+        t("sim_location"),
         value=default_location_text,
-        key=f"location_text_{scenario_key}",
-        help="演示版先手动模拟位置，后续可以直接替换为真实可穿戴设备上报的位置。",
+        key=f"location_text_{locale}_{scenario_key}",
+        help=t("sim_location_help"),
     ).strip()
     if location_text:
         for payload in [alert_payload, safe_payload]:
@@ -354,44 +454,45 @@ with col3:
             location.setdefault("source", "demo_manual_override")
             payload["location"] = location
 
-    if scenario["description"]:
-        st.info(scenario["description"])
-    st.caption("当前位置为演示定位字段，未来可直接替换为真实智能可穿戴设备上报的位置。")
-    if st.button("发送当前异常场景", type="primary", use_container_width=True):
+    scenario_description = scenario.get("description_en") if locale == "en" else scenario.get("description")
+    if scenario_description:
+        st.info(scenario_description)
+    st.caption(t("location_caption"))
+    if st.button(t("send_alert"), type="primary", use_container_width=True):
         try:
             st.session_state["signal_result"] = send_signal(alert_payload)
         except Exception as e:
             st.session_state["signal_result"] = {"status": "error", "msg": str(e)}
-    if st.button("发送当前正常样本", use_container_width=True):
+    if st.button(t("send_safe"), use_container_width=True):
         try:
             st.session_state["signal_result"] = send_signal(safe_payload)
         except Exception as e:
             st.session_state["signal_result"] = {"status": "error", "msg": str(e)}
-    st.markdown("**异常样本 payload**")
+    st.markdown(t("alert_payload"))
     st.json(alert_payload)
-    st.markdown("**正常样本 payload**")
+    st.markdown(t("safe_payload"))
     st.json(safe_payload)
 
-    st.markdown("**最近一次信号处理结果**")
-    st.json(st.session_state.get("signal_result", {"status": "not_triggered"}))
+    st.markdown(t("last_result"))
+    st.json(st.session_state.get("signal_result", {"status": t("not_triggered")}))
 
 st.divider()
 
 left, right = st.columns(2)
 with left:
-    st.subheader("年轻人节点日志")
+    st.subheader(t("young_log"))
     st.code(read_log_tail(YOUNG_LOG), language="text")
 with right:
-    st.subheader("老人节点日志")
+    st.subheader(t("elder_log"))
     st.code(read_log_tail(ELDER_LOG), language="text")
 
 if "young_start" in st.session_state:
-    st.info(f"年轻人节点启动结果: {st.session_state['young_start']}")
+    st.info(t("young_start_result", value=st.session_state["young_start"]))
 if "elder_start" in st.session_state:
-    st.info(f"老人节点启动结果: {st.session_state['elder_start']}")
+    st.info(t("elder_start_result", value=st.session_state["elder_start"]))
 if "bind_result" in st.session_state:
-    st.success(f"绑定结果: {st.session_state['bind_result']}")
+    st.success(t("bind_result", value=st.session_state["bind_result"]))
 if "stop_result" in st.session_state:
-    st.warning(f"停止结果: {st.session_state['stop_result']}")
+    st.warning(t("stop_result", value=st.session_state["stop_result"]))
 if "reset_result" in st.session_state:
-    st.info(f"重置结果: {st.session_state['reset_result']}")
+    st.info(t("reset_result", value=st.session_state["reset_result"]))

--- a/demo/meal_plan_demo_app.py
+++ b/demo/meal_plan_demo_app.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import lark_oapi as lark
 import streamlit as st
+from PIL import Image
 from lark_oapi.api.im.v1 import CreateMessageRequest, CreateMessageRequestBody
 from lark_oapi.api.im.v1 import CreateImageRequest, CreateImageRequestBody
 
@@ -75,8 +76,108 @@ DEMO_FSAPP_PID = TEMP_DIR / "demo_fsapp.pid"
 
 DEFAULT_ADB_SOCKET = os.environ.get("ADB_SERVER_SOCKET", "tcp:127.0.0.1:15038")
 DEFAULT_REQUEST = "我想减肥，给我未来一个月的用餐计划，中午12点吃饭，晚饭18点半。"
+DEFAULT_REQUEST_EN = "I want to lose weight. Give me a meal plan for the next month. Lunch at 12:00, dinner at 18:30."
 DEFAULT_MEAL = "lunch"
 TARGET_OPEN_ID = str((getattr(mykey, "fs_external_alert_targets", {}) or {}).get("child_01", "") or "")
+
+UI_TEXT = {
+    "zh": {
+        "title": "HealthClaw饮食计划与推荐演示",
+        "caption": "这套 demo 会实际走：饮食计划生成 -> 真机美团搜索 -> 候选餐推荐 -> 尝试加入购物车 -> 飞书推送。",
+        "section_env": "1. 环境检查",
+        "check_phone": "检查手机链路",
+        "start_fsapp": "启动飞书服务",
+        "stop_fsapp": "停止飞书服务",
+        "reset_demo": "重置 demo 数据",
+        "phone_status": "**手机状态**",
+        "target_open_id": "**飞书目标 open_id**",
+        "push_target": "推送目标 open_id",
+        "fsapp_status": "**fsapp 启动结果**",
+        "section_plan": "2. 生成饮食计划",
+        "request_label": "需求描述",
+        "generate_plan": "生成月度饮食计划",
+        "plan_summary": "**计划摘要**",
+        "plan_preview": "**计划 JSON 预览**",
+        "plan_empty": "先在这里生成一条月度饮食计划。",
+        "section_live": "3. 执行真实推荐",
+        "choose_meal": "选择本餐",
+        "query_override": "手机美团搜索词覆盖",
+        "query_override_help": "如果你想演示更稳定的真机结果，可以在这里手动指定搜索词。",
+        "progress_title": "**实时执行过程**",
+        "run_flow": "执行本餐推荐流程",
+        "push_to_feishu": "将本餐推荐推送到飞书",
+        "need_plan": "请先生成饮食计划。",
+        "need_push": "请先执行本餐推荐流程。",
+        "fallback_error": "当前 demo 发生了回退，这不符合“全真实链路”要求。请重新执行并排查手机链路。",
+        "live_warning": "真实链路未完全打通：{status} / {message}",
+        "push_preview": "**最终推送文案预览**",
+        "live_json": "**执行结果 JSON**",
+        "feishu_sent": "已发送飞书测试消息: {message_id}",
+        "llm_process": "**LLM 执行过程**",
+        "llm_error": "LLM 调用失败: {error}",
+        "llm_empty": "LLM 返回为空。",
+        "llm_model": "模型: {model}",
+        "llm_input": "查看发给 LLM 的输入",
+        "llm_output": "查看 LLM 输出",
+        "empty_output": "(empty output)",
+        "result_empty": "点“执行本餐推荐流程”后，这里会展示完整推荐结果。",
+        "result_page": "搜索结果页",
+        "merchant_page": "店铺页",
+        "cart_page": "购物车/规格页",
+        "no_image": "暂无截图",
+        "demo_log": "Demo 日志",
+        "fsapp_log": "fsapp 日志",
+        "feishu_test_title": "**测试消息：饮食计划推荐流程演示**\n\n",
+    },
+    "en": {
+        "title": "HealthClaw Meal-plan Recommendation Demo",
+        "caption": "This demo walks through the real chain: meal-plan generation -> phone Meituan search -> candidate recommendations -> add-to-cart attempt -> Feishu push.",
+        "section_env": "1. Environment Check",
+        "check_phone": "Check phone chain",
+        "start_fsapp": "Start Feishu service",
+        "stop_fsapp": "Stop Feishu service",
+        "reset_demo": "Reset demo data",
+        "phone_status": "**Phone status**",
+        "target_open_id": "**Feishu target open_id**",
+        "push_target": "Push target open_id",
+        "fsapp_status": "**fsapp start result**",
+        "section_plan": "2. Generate Meal Plan",
+        "request_label": "Request",
+        "generate_plan": "Generate monthly meal plan",
+        "plan_summary": "**Plan summary**",
+        "plan_preview": "**Plan JSON preview**",
+        "plan_empty": "Generate a monthly meal plan here first.",
+        "section_live": "3. Run Live Recommendation",
+        "choose_meal": "Choose meal",
+        "query_override": "Phone Meituan query override",
+        "query_override_help": "For a more stable live-phone demo, you can manually set the Meituan query here.",
+        "progress_title": "**Live execution log**",
+        "run_flow": "Run this meal flow",
+        "push_to_feishu": "Push this meal result to Feishu",
+        "need_plan": "Generate a meal plan first.",
+        "need_push": "Run the meal flow first.",
+        "fallback_error": "The demo fell back to local data, which breaks the fully live-chain requirement. Please retry and check the phone chain.",
+        "live_warning": "The live chain is not fully connected yet: {status} / {message}",
+        "push_preview": "**Final push preview**",
+        "live_json": "**Execution result JSON**",
+        "feishu_sent": "Feishu test message sent: {message_id}",
+        "llm_process": "**LLM execution details**",
+        "llm_error": "LLM call failed: {error}",
+        "llm_empty": "LLM returned an empty response.",
+        "llm_model": "Model: {model}",
+        "llm_input": "View LLM input",
+        "llm_output": "View LLM output",
+        "empty_output": "(empty output)",
+        "result_empty": "Run the meal flow and the full result will appear here.",
+        "result_page": "Search results page",
+        "merchant_page": "Merchant page",
+        "cart_page": "Cart / spec page",
+        "no_image": "No screenshot yet",
+        "demo_log": "Demo log",
+        "fsapp_log": "fsapp log",
+        "feishu_test_title": "**Test message: meal-plan recommendation demo**\n\n",
+    },
+}
 
 
 def _strip_protocol_tags(text):
@@ -89,20 +190,87 @@ def _strip_protocol_tags(text):
     return text.strip()
 
 
-def build_meal_demo_prompt(plan, push, live):
+def _normalize_locale(locale):
+    return "en" if str(locale or "").strip().lower().startswith("en") else "zh"
+
+
+def _meal_label_display(meal_key, locale):
+    labels = {
+        "zh": {"breakfast": "早餐", "lunch": "午餐", "dinner": "晚餐"},
+        "en": {"breakfast": "Breakfast", "lunch": "Lunch", "dinner": "Dinner"},
+    }
+    loc = _normalize_locale(locale)
+    return labels[loc].get(meal_key, meal_key)
+
+
+def _localized_plan_preview(plan, locale):
+    loc = _normalize_locale(locale)
+    preview_schedule = {}
+    for meal_key in ["breakfast", "lunch", "dinner"]:
+        schedule = copy.deepcopy(plan["meal_schedule"][meal_key])
+        schedule["label"] = schedule.get("label_en") if loc == "en" else schedule.get("label")
+        preview_schedule[meal_key] = schedule
+
+    day_preview = copy.deepcopy(plan["days"][0])
+    if loc == "en":
+        day_preview["theme"] = day_preview.get("theme_en") or day_preview.get("theme")
+        for meal in day_preview.get("meals", {}).values():
+            meal["meal_label"] = meal.get("meal_label_en") or meal.get("meal_label")
+            meal["goal_note"] = meal.get("goal_note_en") or meal.get("goal_note")
+            meal["query"] = meal.get("query_en_display") or meal.get("query")
+
+    return {
+        "goal": plan.get("goal_label_en") if loc == "en" else plan.get("goal_label"),
+        "start_date": plan["start_date"],
+        "meal_schedule": preview_schedule,
+        "day_1": day_preview,
+    }
+
+
+def build_meal_demo_prompt(plan, push, live, locale="zh"):
+    loc = _normalize_locale(locale)
     plan_summary = {
-        "goal_label": plan.get("goal_label", ""),
-        "summary": plan.get("summary", ""),
+        "goal_label": plan.get("goal_label_en", "") if loc == "en" else plan.get("goal_label", ""),
+        "summary": plan.get("summary_en", "") if loc == "en" else plan.get("summary", ""),
         "meal_time": push.get("meal_time", ""),
-        "meal_label": push.get("meal_label", ""),
-        "day_theme": (push.get("day_plan") or {}).get("theme", ""),
-        "meal_spec": push.get("meal_spec", {}),
-        "display_candidates": push.get("display_candidates", []),
+        "meal_label": push.get("meal_label_en", "") if loc == "en" else push.get("meal_label", ""),
+        "day_theme": (push.get("day_plan") or {}).get("theme_en", "") if loc == "en" else (push.get("day_plan") or {}).get("theme", ""),
+        "meal_spec": {
+            **(push.get("meal_spec") or {}),
+            "meal_label": (push.get("meal_spec") or {}).get("meal_label_en") if loc == "en" else (push.get("meal_spec") or {}).get("meal_label"),
+            "goal_note": (push.get("meal_spec") or {}).get("goal_note_en") if loc == "en" else (push.get("meal_spec") or {}).get("goal_note"),
+            "query": (push.get("meal_spec") or {}).get("query_en_display") if loc == "en" else (push.get("meal_spec") or {}).get("query"),
+        },
+        "display_candidates": [
+            {
+                **item,
+                "reason": item.get("reason_en") if loc == "en" else item.get("reason"),
+            }
+            for item in (push.get("display_candidates") or [])
+        ],
         "cart_action": push.get("cart_action", {}),
         "live_status": live.get("live_status", ""),
         "live_message": live.get("live_message", ""),
         "fallback_used": live.get("fallback_used", False),
     }
+    if loc == "en":
+        return (
+            "You are the HealthClaw meal recommendation explainer. "
+            "Based on the real execution result below, explain why this breakfast, lunch, or dinner recommendation was chosen. "
+            "Do not invent Meituan results that were not actually observed, and do not claim payment has already happened.\n\n"
+            "Output requirements:\n"
+            "1. Use English.\n"
+            "2. Output Markdown.\n"
+            "3. You must include these headings:\n"
+            "**LLM Summary**\n"
+            "**Why These Candidates Were Recommended**\n"
+            "**Where The Real Chain Stopped**\n"
+            "**What To Do Next**\n"
+            "4. If add-to-cart failed, clearly say which step failed.\n"
+            "5. If an item was added to cart, clearly state that payment has not happened yet and still requires manual payment.\n\n"
+            "Input data:\n"
+            f"```json\n{json.dumps(plan_summary, ensure_ascii=False, indent=2)}\n```"
+        )
     return (
         "你是 HealthClaw 饮食推荐解释器。"
         "请根据以下真实执行结果，解释这次早餐/午餐/晚餐推荐为什么这样选。"
@@ -144,8 +312,8 @@ def _default_llm_ask(prompt):
     raise RuntimeError("; ".join(errors) or "all_llm_backends_failed")
 
 
-def explain_meal_demo(plan, push, live, llm_ask=None):
-    prompt = build_meal_demo_prompt(plan, push, live)
+def explain_meal_demo(plan, push, live, locale="zh", llm_ask=None):
+    prompt = build_meal_demo_prompt(plan, push, live, locale=locale)
     ask = llm_ask or _default_llm_ask
     try:
         result = ask(prompt)
@@ -242,9 +410,19 @@ def send_feishu_card(open_id, content):
     return result.data.message_id
 
 
+def _prepare_feishu_upload_image(image_path):
+    src = Path(image_path)
+    prepared = TEMP_DIR / f"{src.stem}_feishu.jpg"
+    with Image.open(src) as image:
+        normalized = image.convert("RGB")
+        normalized.save(prepared, format="JPEG", quality=92, optimize=True)
+    return str(prepared)
+
+
 def upload_feishu_image(image_path):
     client = create_feishu_client()
-    with open(image_path, "rb") as image_file:
+    prepared_path = _prepare_feishu_upload_image(image_path)
+    with open(prepared_path, "rb") as image_file:
         body = CreateImageRequestBody.builder().image_type("message").image(image_file).build()
         req = CreateImageRequest.builder().request_body(body).build()
         result = client.im.v1.image.create(req)
@@ -269,13 +447,14 @@ def send_feishu_image(open_id, image_path):
     return result.data.message_id
 
 
-def send_feishu_demo_bundle(open_id, content, artifacts):
+def send_feishu_demo_bundle(open_id, content, artifacts, locale="zh"):
+    labels = (
+        [("搜索结果页截图", artifacts.get("result_screenshot", "")), ("店铺页截图", artifacts.get("merchant_screenshot", "")), ("购物车页截图", artifacts.get("cart_screenshot", ""))]
+        if _normalize_locale(locale) != "en"
+        else [("Search results screenshot", artifacts.get("result_screenshot", "")), ("Merchant page screenshot", artifacts.get("merchant_screenshot", "")), ("Cart page screenshot", artifacts.get("cart_screenshot", ""))]
+    )
     message_ids = {"main": send_feishu_card(open_id, content), "images": []}
-    for label, path in [
-        ("搜索结果页截图", artifacts.get("result_screenshot", "")),
-        ("店铺页截图", artifacts.get("merchant_screenshot", "")),
-        ("购物车页截图", artifacts.get("cart_screenshot", "")),
-    ]:
+    for label, path in labels:
         if not path or not Path(path).exists():
             continue
         text_id = send_feishu_card(open_id, f"**{label}**")
@@ -368,6 +547,7 @@ def build_demo_push(service, plan, meal_key, query_override=""):
         "date": time.strftime("%Y-%m-%d"),
         "meal_key": meal_key,
         "meal_label": aligned_plan["meal_schedule"][meal_key]["label"],
+        "meal_label_en": aligned_plan["meal_schedule"][meal_key].get("label_en", ""),
         "meal_time": aligned_plan["meal_schedule"][meal_key]["meal_time"],
         "day_plan": aligned_plan["days"][0],
         "meal_spec": aligned_plan["days"][0]["meals"][meal_key],
@@ -384,20 +564,20 @@ def phone_status(adb_socket):
     return {"connected": ok, "info": info, "adb_socket": os.environ.get("ADB_SERVER_SOCKET")}
 
 
-def append_progress(logs, message, placeholder=None):
+def append_progress(logs, message, placeholder=None, locale="zh"):
     timestamp = datetime.now().strftime("%H:%M:%S")
     logs.append(f"[{timestamp}] {message}")
     st.session_state["demo_progress_log"] = logs
     if placeholder is not None:
         placeholder.markdown(
-            "**实时执行过程**\n\n" + "\n".join(f"- {item}" for item in logs)
+            (UI_TEXT[_normalize_locale(locale)]["progress_title"] + "\n\n" + "\n".join(f"- {item}" for item in logs))
         )
 
 
-st.set_page_config(page_title="HealthClaw饮食计划演示", layout="wide")
-st.title("HealthClaw饮食计划与推荐演示")
-st.caption("这套 demo 会实际走：饮食计划生成 -> 真机美团搜索 -> 候选餐推荐 -> 尝试加入购物车 -> 飞书推送。")
+st.set_page_config(page_title="HealthClaw Meal Demo", layout="wide")
 
+if "meal_demo_locale" not in st.session_state:
+    st.session_state["meal_demo_locale"] = "zh"
 if "demo_plan" not in st.session_state:
     st.session_state["demo_plan"] = None
 if "demo_push" not in st.session_state:
@@ -413,89 +593,108 @@ if "demo_llm_debug" not in st.session_state:
 if "demo_progress_log" not in st.session_state:
     st.session_state["demo_progress_log"] = []
 
+locale = st.selectbox(
+    "Language / 语言",
+    ["zh", "en"],
+    index=0 if st.session_state.get("meal_demo_locale", "zh") == "zh" else 1,
+    format_func=lambda value: "中文" if value == "zh" else "English",
+)
+st.session_state["meal_demo_locale"] = locale
+
+
+def t(key, **kwargs):
+    text = UI_TEXT[locale][key]
+    return text.format(**kwargs) if kwargs else text
+
+
+st.title(t("title"))
+st.caption(t("caption"))
+
 col1, col2, col3 = st.columns(3)
 
 with col1:
-    st.subheader("1. 环境检查")
+    st.subheader(t("section_env"))
     adb_socket = st.text_input("ADB_SERVER_SOCKET", value=DEFAULT_ADB_SOCKET)
     ensure_runtime_env(adb_socket)
-    if st.button("检查手机链路", use_container_width=True):
+    if st.button(t("check_phone"), use_container_width=True):
         st.session_state["phone_status"] = phone_status(adb_socket)
-    if st.button("启动飞书服务", use_container_width=True):
+    if st.button(t("start_fsapp"), use_container_width=True):
         st.session_state["fsapp_status"] = start_fsapp(adb_socket)
-    if st.button("停止飞书服务", use_container_width=True):
+    if st.button(t("stop_fsapp"), use_container_width=True):
         st.session_state["fsapp_stop"] = {"stopped": stop_process(DEMO_FSAPP_PID)}
-    if st.button("重置 demo 数据", use_container_width=True):
+    if st.button(t("reset_demo"), use_container_width=True):
         reset_demo_user_data()
         st.session_state["demo_plan"] = None
         st.session_state["demo_push"] = None
         st.session_state["demo_live"] = None
         st.session_state["demo_message_id"] = ""
+        st.session_state["demo_message_bundle"] = None
+        st.session_state["demo_llm_debug"] = None
         st.session_state["demo_progress_log"] = []
 
-    st.markdown("**手机状态**")
+    st.markdown(t("phone_status"))
     st.json(st.session_state.get("phone_status", phone_status(adb_socket)))
-    st.markdown("**飞书目标 open_id**")
-    open_id = st.text_input("推送目标 open_id", value=TARGET_OPEN_ID)
-    st.markdown("**fsapp 启动结果**")
+    st.markdown(t("target_open_id"))
+    open_id = st.text_input(t("push_target"), value=TARGET_OPEN_ID)
+    st.markdown(t("fsapp_status"))
     st.json(st.session_state.get("fsapp_status", {"status": "idle"}))
 
 with col2:
-    st.subheader("2. 生成饮食计划")
-    request_text = st.text_area("需求描述", value=DEFAULT_REQUEST, height=120)
-    if st.button("生成月度饮食计划", type="primary", use_container_width=True):
+    st.subheader(t("section_plan"))
+    request_text = st.text_area(
+        t("request_label"),
+        value=DEFAULT_REQUEST if locale == "zh" else DEFAULT_REQUEST_EN,
+        height=120,
+        key=f"meal_request_{locale}",
+    )
+    if st.button(t("generate_plan"), type="primary", use_container_width=True):
         service = get_demo_service()
         plan = service.create_plan(open_id or "meal_demo_user", request_text)["plan"]
         st.session_state["demo_plan"] = plan
-        st.session_state["demo_plan_message"] = service.format_plan_created_message(plan)
         log_demo(f"已生成 demo 饮食计划，goal={plan['goal']}, open_id={plan['open_id']}")
 
     if st.session_state.get("demo_plan"):
+        service = get_demo_service()
         plan = st.session_state["demo_plan"]
-        st.markdown("**计划摘要**")
-        st.markdown(st.session_state.get("demo_plan_message", ""))
-        preview = {
-            "goal": plan["goal_label"],
-            "start_date": plan["start_date"],
-            "meal_schedule": plan["meal_schedule"],
-            "day_1": plan["days"][0],
-        }
-        st.markdown("**计划 JSON 预览**")
-        st.json(preview)
+        st.markdown(t("plan_summary"))
+        st.markdown(service.format_plan_created_message(plan, locale=locale))
+        st.markdown(t("plan_preview"))
+        st.json(_localized_plan_preview(plan, locale))
     else:
-        st.info("先在这里生成一条月度饮食计划。")
+        st.info(t("plan_empty"))
 
 with col3:
-    st.subheader("3. 执行真实推荐")
+    st.subheader(t("section_live"))
     meal_key = st.selectbox(
-        "选择本餐",
+        t("choose_meal"),
         ["breakfast", "lunch", "dinner"],
         index=["breakfast", "lunch", "dinner"].index(DEFAULT_MEAL),
-        format_func=lambda key: {"breakfast": "早餐", "lunch": "午餐", "dinner": "晚餐"}[key],
+        format_func=lambda key: _meal_label_display(key, locale),
     )
     query_override = st.text_input(
-        "手机美团搜索词覆盖",
+        t("query_override"),
         value="鸡胸肉蔬菜沙拉" if meal_key == "lunch" else "",
-        help="如果你想演示更稳定的真机结果，可以在这里手动指定搜索词。",
+        help=t("query_override_help"),
+        key=f"meal_query_override_{locale}_{meal_key}",
     )
     progress_placeholder = st.empty()
     if st.session_state.get("demo_progress_log"):
         progress_placeholder.markdown(
-            "**实时执行过程**\n\n" + "\n".join(f"- {item}" for item in st.session_state["demo_progress_log"])
+            t("progress_title") + "\n\n" + "\n".join(f"- {item}" for item in st.session_state["demo_progress_log"])
         )
-    if st.button("执行本餐推荐流程", type="primary", use_container_width=True):
+    if st.button(t("run_flow"), type="primary", use_container_width=True):
         if not st.session_state.get("demo_plan"):
-            st.warning("请先生成饮食计划。")
+            st.warning(t("need_plan"))
         else:
             logs = []
-            append_progress(logs, f"开始执行{ {'breakfast':'早餐','lunch':'午餐','dinner':'晚餐'}[meal_key] }推荐流程", progress_placeholder)
             service = get_demo_service()
-            append_progress(logs, "正在对齐今日计划与演示时间", progress_placeholder)
+            append_progress(logs, f"开始执行{_meal_label_display(meal_key, locale)}推荐流程" if locale == "zh" else f"Starting the {_meal_label_display(meal_key, locale)} recommendation flow", progress_placeholder, locale=locale)
+            append_progress(logs, "正在对齐今日计划与演示时间" if locale == "zh" else "Aligning the plan with today's demo time", progress_placeholder, locale=locale)
             aligned_plan = align_plan_for_demo(st.session_state["demo_plan"], meal_key, query_override=query_override)
-            append_progress(logs, "正在重置美团 App 状态", progress_placeholder)
+            append_progress(logs, "正在重置美团 App 状态" if locale == "zh" else "Resetting the Meituan app state", progress_placeholder, locale=locale)
             _run_adb("shell", "am", "force-stop", "com.sankuai.meituan", timeout=20)
             time.sleep(1)
-            append_progress(logs, "正在执行真实手机美团链路（搜索 -> 结果页 -> 店铺页）", progress_placeholder)
+            append_progress(logs, "正在执行真实手机美团链路（搜索 -> 结果页 -> 店铺页）" if locale == "zh" else "Running the real phone Meituan chain (search -> results -> merchant page)", progress_placeholder, locale=locale)
             live = service.prepare_live_meituan_push(
                 aligned_plan,
                 meal_key,
@@ -505,16 +704,22 @@ with col3:
             )
             append_progress(
                 logs,
-                f"真实链路返回：status={live.get('live_status', '') or live.get('status', '')} / fallback={live.get('fallback_used')}",
+                (
+                    f"真实链路返回：status={live.get('live_status', '') or live.get('status', '')} / fallback={live.get('fallback_used')}"
+                    if locale == "zh"
+                    else f"Live chain returned: status={live.get('live_status', '') or live.get('status', '')} / fallback={live.get('fallback_used')}"
+                ),
                 progress_placeholder,
+                locale=locale,
             )
-            append_progress(logs, "正在整理候选餐与推送文案", progress_placeholder)
+            append_progress(logs, "正在整理候选餐与推送文案" if locale == "zh" else "Formatting candidates and push copy", progress_placeholder, locale=locale)
             push = {
                 "plan_id": aligned_plan["id"],
                 "open_id": aligned_plan["open_id"],
                 "date": time.strftime("%Y-%m-%d"),
                 "meal_key": meal_key,
                 "meal_label": aligned_plan["meal_schedule"][meal_key]["label"],
+                "meal_label_en": aligned_plan["meal_schedule"][meal_key].get("label_en", ""),
                 "meal_time": aligned_plan["meal_schedule"][meal_key]["meal_time"],
                 "day_plan": aligned_plan["days"][0],
                 "meal_spec": aligned_plan["days"][0]["meals"][meal_key],
@@ -525,99 +730,108 @@ with col3:
             st.session_state["demo_plan"] = aligned_plan
             st.session_state["demo_live"] = live
             st.session_state["demo_push"] = push
-            st.session_state["demo_push_message"] = service.format_push_message(push)
-            append_progress(logs, "正在调用 LLM 解释推荐结果", progress_placeholder)
-            st.session_state["demo_llm_debug"] = explain_meal_demo(aligned_plan, push, live)
+            append_progress(logs, "正在调用 LLM 解释推荐结果" if locale == "zh" else "Calling the LLM to explain the recommendation", progress_placeholder, locale=locale)
+            st.session_state["demo_llm_debug"] = explain_meal_demo(aligned_plan, push, live, locale=locale)
             llm_debug = st.session_state["demo_llm_debug"]
             append_progress(
                 logs,
-                f"LLM 执行完成：status={llm_debug.get('status', '')} / model={llm_debug.get('model', '') or 'unknown'}",
+                (
+                    f"LLM 执行完成：status={llm_debug.get('status', '')} / model={llm_debug.get('model', '') or 'unknown'}"
+                    if locale == "zh"
+                    else f"LLM finished: status={llm_debug.get('status', '')} / model={llm_debug.get('model', '') or 'unknown'}"
+                ),
                 progress_placeholder,
+                locale=locale,
             )
-            append_progress(logs, "本餐推荐流程执行完成，下面展示最终结果", progress_placeholder)
+            append_progress(logs, "本餐推荐流程执行完成，下面展示最终结果" if locale == "zh" else "The meal flow is complete. Final results are shown below.", progress_placeholder, locale=locale)
             log_demo(
                 f"已执行 {meal_key} 推荐流程，cart_action={live.get('cart_action', {}).get('status', '')}, "
                 f"source={live.get('source', '')}, fallback_used={live.get('fallback_used')}, "
                 f"live_status={live.get('live_status', '')}"
             )
-    if st.button("将本餐推荐推送到飞书", use_container_width=True):
+    if st.button(t("push_to_feishu"), use_container_width=True):
         if not st.session_state.get("demo_push"):
-            st.warning("请先执行本餐推荐流程。")
+            st.warning(t("need_push"))
         else:
-            content = "**测试消息：饮食计划推荐流程演示**\n\n" + st.session_state.get("demo_push_message", "")
+            service = get_demo_service()
+            push_message = service.format_push_message(st.session_state["demo_push"], locale=locale)
+            content = t("feishu_test_title") + push_message
             message_bundle = send_feishu_demo_bundle(
                 open_id,
                 content,
                 (st.session_state.get("demo_push") or {}).get("artifacts", {}),
+                locale=locale,
             )
             st.session_state["demo_message_id"] = message_bundle["main"]
             st.session_state["demo_message_bundle"] = message_bundle
             log_demo(f"已发送 demo 飞书消息，message_id={message_bundle['main']}")
 
     if st.session_state.get("demo_push"):
+        service = get_demo_service()
         live = st.session_state.get("demo_live", {})
+        push_message = service.format_push_message(st.session_state["demo_push"], locale=locale)
         if live.get("fallback_used"):
-            st.error("当前 demo 发生了回退，这不符合“全真实链路”要求。请重新执行并排查手机链路。")
+            st.error(t("fallback_error"))
         elif live.get("live_status") not in {"success", "partial"}:
-            st.warning(f"真实链路未完全打通：{live.get('live_status')} / {live.get('live_message', '')}")
-        st.markdown("**最终推送文案预览**")
-        st.markdown(st.session_state.get("demo_push_message", ""))
-        st.markdown("**执行结果 JSON**")
+            st.warning(t("live_warning", status=live.get("live_status"), message=live.get("live_message", "")))
+        st.markdown(t("push_preview"))
+        st.markdown(push_message)
+        st.markdown(t("live_json"))
         st.json(live)
         if st.session_state.get("demo_message_id"):
-            st.success(f"已发送飞书测试消息: {st.session_state['demo_message_id']}")
+            st.success(t("feishu_sent", message_id=st.session_state["demo_message_id"]))
         if st.session_state.get("demo_message_bundle"):
             st.json(st.session_state["demo_message_bundle"])
         llm_debug = st.session_state.get("demo_llm_debug")
         if llm_debug:
-            st.markdown("**LLM 执行过程**")
+            st.markdown(t("llm_process"))
             if llm_debug.get("status") == "error":
-                st.warning(f"LLM 调用失败: {llm_debug.get('error', '')}")
+                st.warning(t("llm_error", error=llm_debug.get("error", "")))
             elif llm_debug.get("status") == "empty":
-                st.warning("LLM 返回为空。")
+                st.warning(t("llm_empty"))
             else:
-                st.caption(f"模型: {llm_debug.get('model', 'unknown')}")
-            with st.expander("查看发给 LLM 的输入", expanded=False):
+                st.caption(t("llm_model", model=llm_debug.get("model", "unknown")))
+            with st.expander(t("llm_input"), expanded=False):
                 st.code(llm_debug.get("prompt", ""), language="text")
-            with st.expander("查看 LLM 输出", expanded=True):
+            with st.expander(t("llm_output"), expanded=True):
                 output = llm_debug.get("output", "")
                 if output:
                     st.markdown(output)
                 else:
-                    st.code("(empty output)", language="text")
+                    st.code(t("empty_output"), language="text")
     else:
-        st.info("点“执行本餐推荐流程”后，这里会展示完整推荐结果。")
+        st.info(t("result_empty"))
 
 st.divider()
 img_col1, img_col2, img_col3 = st.columns(3)
 artifacts = (st.session_state.get("demo_push") or {}).get("artifacts", {})
 with img_col1:
-    st.subheader("搜索结果页")
+    st.subheader(t("result_page"))
     result_path = artifacts.get("result_screenshot", "")
     if result_path and Path(result_path).exists():
         st.image(result_path, caption=Path(result_path).name)
     else:
-        st.caption("暂无截图")
+        st.caption(t("no_image"))
 with img_col2:
-    st.subheader("店铺页")
+    st.subheader(t("merchant_page"))
     merchant_path = artifacts.get("merchant_screenshot", "")
     if merchant_path and Path(merchant_path).exists():
         st.image(merchant_path, caption=Path(merchant_path).name)
     else:
-        st.caption("暂无截图")
+        st.caption(t("no_image"))
 with img_col3:
-    st.subheader("购物车页")
+    st.subheader(t("cart_page"))
     cart_path = artifacts.get("cart_screenshot", "")
     if cart_path and Path(cart_path).exists():
         st.image(cart_path, caption=Path(cart_path).name)
     else:
-        st.caption("暂无截图")
+        st.caption(t("no_image"))
 
 st.divider()
 left, right = st.columns(2)
 with left:
-    st.subheader("Demo 日志")
+    st.subheader(t("demo_log"))
     st.code(read_log_tail(DEMO_LOG), language="text")
 with right:
-    st.subheader("fsapp 日志")
+    st.subheader(t("fsapp_log"))
     st.code(read_log_tail(DEMO_FSAPP_LOG), language="text")

--- a/docs/showcase/README.md
+++ b/docs/showcase/README.md
@@ -36,15 +36,15 @@ but tries to explain what happened so the right person gets it in time and under
 
 <p align="center">
   <video
-    poster="../readme_media/showcase_amap_hospital_cover_en.png"
-    src="https://github.com/user-attachments/assets/6afaa031-aad4-4a47-8c9d-0c03c902a448"
+    poster="../readme_media/showcase_amap_hospital_cover.png"
+    src="https://github.com/user-attachments/assets/75a6ccb7-4b65-4d64-aa63-1820f004e9d6"
     controls
     muted
     playsinline
     preload="metadata"
     width="800"
   >
-    If the player does not appear, <a href="https://github.com/user-attachments/assets/6afaa031-aad4-4a47-8c9d-0c03c902a448">open the video directly</a>.
+    If the player does not appear, <a href="https://github.com/user-attachments/assets/75a6ccb7-4b65-4d64-aa63-1820f004e9d6">open the video directly</a>.
   </video>
 </p>
 
@@ -59,15 +59,15 @@ and bridge “knowing you should go” to “actually starting to go”—you on
 
 <p align="center">
   <video
-    poster="../readme_media/showcase_genomics_cover_en.png"
-    src="https://github.com/user-attachments/assets/866eed2b-d231-4c2c-b5b8-c3b059641524"
+    poster="../readme_media/showcase_genomics_cover.png"
+    src="https://github.com/user-attachments/assets/90e4d536-c684-4da4-af74-92e84cb00430"
     controls
     muted
     playsinline
     preload="metadata"
     width="800"
   >
-    If the player does not appear, <a href="https://github.com/user-attachments/assets/866eed2b-d231-4c2c-b5b8-c3b059641524">open the video directly</a>.
+    If the player does not appear, <a href="https://github.com/user-attachments/assets/90e4d536-c684-4da4-af74-92e84cb00430">open the video directly</a>.
   </video>
 </p>
 
@@ -82,15 +82,15 @@ turning heavy pipelines into easier-to-read takeaways.</em></p>
 
 <p align="center">
   <video
-    poster="../readme_media/showcase_proteomics_cover_en.png"
-    src="https://github.com/user-attachments/assets/a3733323-9a9e-4793-b77f-a3d1f488e392"
+    poster="../readme_media/showcase_proteomics_cover.png"
+    src="https://github.com/user-attachments/assets/a2eb84ff-9450-4297-9306-95bcc5dfeecc"
     controls
     muted
     playsinline
     preload="metadata"
     width="800"
   >
-    If the player does not appear, <a href="https://github.com/user-attachments/assets/a3733323-9a9e-4793-b77f-a3d1f488e392">open the video directly</a>.
+    If the player does not appear, <a href="https://github.com/user-attachments/assets/a2eb84ff-9450-4297-9306-95bcc5dfeecc">open the video directly</a>.
   </video>
 </p>
 
@@ -105,15 +105,15 @@ to assist clinicians and help patients understand.</em></p>
 
 <p align="center">
   <video
-    poster="../readme_media/showcase_imaging_cover_en.png"
-    src="https://github.com/user-attachments/assets/61dff23e-a38d-4219-955b-b4c46d76ead2"
+    poster="../readme_media/showcase_imaging_cover.png"
+    src="https://github.com/user-attachments/assets/f0726feb-a715-47a3-b2d4-e3b4baeae9c4"
     controls
     muted
     playsinline
     preload="metadata"
     width="800"
   >
-    If the player does not appear, <a href="https://github.com/user-attachments/assets/61dff23e-a38d-4219-955b-b4c46d76ead2">open the video directly</a>.
+    If the player does not appear, <a href="https://github.com/user-attachments/assets/f0726feb-a715-47a3-b2d4-e3b4baeae9c4">open the video directly</a>.
   </video>
 </p>
 
@@ -128,15 +128,15 @@ so “watch and wait” vs “go soon” is less of a pure guess.</em></p>
 
 <p align="center">
   <video
-    poster="../readme_media/xiaomi_health_demo_cover_en.png"
-    src="https://github.com/user-attachments/assets/f3021c5a-6ff8-4508-aa6c-0844327ba458"
+    poster="../readme_media/xiaomi_health_demo_cover.png"
+    src="https://github.com/user-attachments/assets/c475b725-ad64-4b02-ac49-d38ffbbc710a"
     controls
     muted
     playsinline
     preload="metadata"
     width="800"
   >
-    If the player does not appear, <a href="https://github.com/user-attachments/assets/f3021c5a-6ff8-4508-aa6c-0844327ba458">open the video directly</a>.
+    If the player does not appear, <a href="https://github.com/user-attachments/assets/c475b725-ad64-4b02-ac49-d38ffbbc710a">open the video directly</a>.
   </video>
 </p>
 
@@ -151,15 +151,15 @@ then suggests practical adjustments rather than a vague “get more rest.”</em
 
 <p align="center">
   <video
-    poster="../readme_media/showcase_huawei_health_cover_en.png"
-    src="https://github.com/user-attachments/assets/6e422338-8289-4e24-a281-d671e992e750"
+    poster="../readme_media/showcase_huawei_health_cover.png"
+    src="https://github.com/user-attachments/assets/2a460a3c-ca07-436c-ab24-3e18d8575e8c"
     controls
     muted
     playsinline
     preload="metadata"
     width="800"
   >
-    If the player does not appear, <a href="https://github.com/user-attachments/assets/6e422338-8289-4e24-a281-d671e992e750">open the video directly</a>.
+    If the player does not appear, <a href="https://github.com/user-attachments/assets/2a460a3c-ca07-436c-ab24-3e18d8575e8c">open the video directly</a>.
   </video>
 </p>
 

--- a/fsapp.py
+++ b/fsapp.py
@@ -1,11 +1,12 @@
 """
-Self-Evolving MedicalClaw — 飞书 Bot 前端
+Self-Evolving HealthClaw — 飞书 Bot 前端
 双模式：WebSocket 事件推送 + API 轮询回退。
 启动: python fsapp.py
 """
 import os, sys, threading, time, re, json, glob, urllib.request
 import importlib.util
 import queue as Q
+from PIL import Image
 
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, PROJECT_ROOT)
@@ -93,6 +94,24 @@ _alert_llm_state = {
 }
 
 
+def _startup_locale():
+    return "en" if str(os.environ.get("HEALTHCLAW_DEMO_LOCALE", "") or "").strip().lower().startswith("en") else "zh"
+
+
+def _startup_online_text(polling=False):
+    if _startup_locale() == "en":
+        if polling:
+            return "🩺 HealthClaw is online (polling mode). You can start chatting now!"
+        return "🩺 HealthClaw is online. You can start chatting now!"
+    if polling:
+        return "🩺 HealthClaw 已上线（轮询模式），可以开始对话！"
+    return "🩺 HealthClaw 已上线，可以开始对话！"
+
+
+def _feishu_application_lang():
+    return "en_us" if _startup_locale() == "en" else "zh_cn"
+
+
 def ensure_agent_ready():
     global agent, agent_init_error
     if agent is not None:
@@ -113,6 +132,13 @@ def ensure_agent_ready():
 def _coerce_int(value, default=0):
     try:
         return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_float(value, default=0.0):
+    try:
+        return float(value)
     except (TypeError, ValueError):
         return default
 
@@ -189,9 +215,47 @@ def _build_direct_fallback_result(alert, error_text="", source="fallback"):
     }
 
 
+def _alert_locale(alert):
+    if not isinstance(alert, dict):
+        return "zh"
+    locale = alert.get("locale")
+    if not locale and isinstance(alert.get("details"), dict):
+        locale = alert["details"].get("locale")
+    return "en" if str(locale or "").strip().lower().startswith("en") else "zh"
+
+
 def build_alert_explanation_prompt(alert):
+    locale = _alert_locale(alert)
     alert_json = json.dumps(alert, ensure_ascii=False, indent=2)
     location_text = _extract_alert_location_text(alert)
+    if locale == "en":
+        location_hint = ""
+        if location_text:
+            location_hint = (
+                f"9. If the alert already includes a location (currently: {location_text}), "
+                "remind the family to contact the closest available person near that location first.\n\n"
+            )
+        return (
+            "You are HealthClaw's caregiver alert explainer. "
+            "Your job is not to decide whether the alert is valid again, but to explain an already-triggered alert to a family member without a medical background.\n\n"
+            "Requirements:\n"
+            "1. Explain only from the provided alert data. Do not invent vitals, location details, history, or test results.\n"
+            "2. Use plain English and avoid heavy medical jargon.\n"
+            "3. Do not give a definitive diagnosis. Use language such as 'may', 'could', 'worth watching', or 'should be confirmed'.\n"
+            "4. Output Markdown and include exactly these 4 headings:\n"
+            "**What This Means**\n"
+            "**Possible Reasons**\n"
+            "**What To Do Now**\n"
+            "**When To Call Emergency Help**\n"
+            "5. Under each heading, write 2-4 short bullet points.\n"
+            "6. If the data is limited, explicitly say that the alert alone is not enough to determine the cause.\n"
+            "7. For high heart rate alerts, remind the family to distinguish a brief post-activity spike from a sustained resting elevation.\n\n"
+            "8. Alerts may come from wearable heart rate, oxygen, fall, rhythm, temperature, or activity signals, so the explanation should match the signal type.\n\n"
+            f"{location_hint}"
+            "Alert data:\n"
+            f"```json\n{alert_json}\n```"
+        )
+
     location_hint = ""
     if location_text:
         location_hint = (
@@ -220,7 +284,201 @@ def build_alert_explanation_prompt(alert):
     )
 
 
+def _build_fallback_alert_explanation_en(alert):
+    event_type = str(alert.get("event_type", "external_alert") or "external_alert")
+    details = alert.get("details") if isinstance(alert.get("details"), dict) else {}
+    heart_rate = _coerce_int(details.get("heart_rate", alert.get("heart_rate")), 0)
+    duration_sec = _coerce_int(details.get("duration_sec", alert.get("duration_sec")), 0)
+    threshold = _coerce_int((details.get("rule") or {}).get("threshold"), 0)
+    spo2 = _coerce_int(details.get("spo2", alert.get("spo2")), 0)
+    impact_g = _coerce_float(details.get("impact_g", alert.get("impact_g")), 0.0)
+    no_movement_sec = _coerce_int(details.get("no_movement_sec", alert.get("no_movement_sec")), 0)
+    episode_count = _coerce_int(details.get("episode_count", alert.get("episode_count")), 0)
+    resting_heart_rate = _coerce_int(details.get("resting_heart_rate", alert.get("resting_heart_rate")), 0)
+    body_temperature = _coerce_float(details.get("body_temperature", alert.get("body_temperature")), 0.0)
+    inactivity_minutes = _coerce_int(details.get("inactivity_minutes", alert.get("inactivity_minutes")), 0)
+    threshold_minutes = _coerce_int((details.get("rule") or {}).get("threshold_minutes"), 0)
+    classification = str(details.get("classification", "") or "")
+
+    if event_type == "heart_rate_alert":
+        threshold_text = f"{threshold} bpm" if threshold > 0 else "the configured threshold"
+        return "\n".join(
+            [
+                "**What This Means**",
+                f"- The wearable detected a heart rate around {heart_rate} bpm for about {duration_sec} seconds, which is above the alert rule.",
+                "- That means the older adult is worth checking on soon, but this alert alone is not enough to identify the exact cause.",
+                "- A sustained elevation at rest is usually more concerning than a brief spike right after activity.",
+                "",
+                "**Possible Reasons**",
+                "- This could reflect recent movement, stress, pain, fever, dehydration, or a loose wearable reading.",
+                f"- It could also reflect an arrhythmia or other acute discomfort, but the alert alone cannot confirm that and only shows a sustained rate above {threshold_text}.",
+                "",
+                "**What To Do Now**",
+                "- Contact the older adult and confirm they are awake, speaking normally, and not alone.",
+                "- Ask about chest discomfort, shortness of breath, dizziness, palpitations, a fall, or clear weakness.",
+                "- If possible, repeat the heart rate check after a short rest and see whether it comes down quickly.",
+                "",
+                "**When To Call Emergency Help**",
+                "- Call emergency help right away if the alert comes with chest pain, severe shortness of breath, fainting, confusion, or one-sided weakness.",
+                "- If the heart rate stays very high at rest and does not come down on repeat checks, urgent in-person care is also appropriate.",
+                "- If the device keeps sending high-risk alerts and the family cannot reach the older adult, treat it as an emergency.",
+            ]
+        )
+
+    if event_type == "blood_oxygen_alert":
+        return "\n".join(
+            [
+                "**What This Means**",
+                f"- The wearable detected oxygen saturation around {spo2}% for about {duration_sec} seconds, which can suggest breathing or circulation risk.",
+                "- This alert alone is not enough to determine the cause, but sustained low oxygen deserves more attention than a brief fluctuation.",
+                "",
+                "**Possible Reasons**",
+                "- This could reflect a respiratory infection, COPD or asthma worsening, another lung issue, or a temporary measurement error.",
+                "- Loose device fit or movement during the reading can also cause a false alarm, so a repeat check matters.",
+                "",
+                "**What To Do Now**",
+                "- Contact the older adult and ask about shortness of breath, chest tightness, fast breathing, blue lips, or unusual fatigue.",
+                "- Ask them to sit upright, stay calm, and repeat the oxygen reading if possible.",
+                "- If home oxygen or prior respiratory history exists, share that information with whoever can check on them in person.",
+                "",
+                "**When To Call Emergency Help**",
+                "- Call emergency help if there is obvious breathing distress, blue lips, confusion, or the older adult cannot speak normally.",
+                "- If repeat checks stay very low or the family cannot reach the older adult at all, treat it as urgent.",
+            ]
+        )
+
+    if event_type == "fall_detected_alert":
+        return "\n".join(
+            [
+                "**What This Means**",
+                f"- The wearable detected a possible fall with about {impact_g:.1f}g of impact and about {no_movement_sec} seconds without clear movement afterward.",
+                "- Fall alerts usually deserve faster on-site confirmation than a single abnormal vital sign because injuries can be hidden.",
+                "",
+                "**Possible Reasons**",
+                "- This may be a true fall, a slip while standing up, or occasionally a strong device impact that caused a false alarm.",
+                "- If there was prolonged stillness afterward, worry more about the older adult being unable to get up alone.",
+                "",
+                "**What To Do Now**",
+                "- Contact the older adult or the nearest caregiver immediately and confirm whether they are awake, speaking, and in pain.",
+                "- If someone is already there, do not force them up immediately before checking for head injury, deformity, or severe pain.",
+                "- If they cannot stand, have strong pain, or may have hit their head, arrange in-person help quickly.",
+                "",
+                "**When To Call Emergency Help**",
+                "- Call emergency help right away for loss of consciousness, head injury, suspected fracture, vomiting, or inability to stand.",
+                "- If the device keeps showing a post-fall no-movement state and no one can reach the older adult, treat it as an emergency.",
+            ]
+        )
+
+    if event_type == "arrhythmia_alert":
+        return "\n".join(
+            [
+                "**What This Means**",
+                f"- The wearable flagged a possible irregular rhythm for about {duration_sec} seconds with about {episode_count} abnormal rhythm segments.",
+                f"- Resting heart rate is around {resting_heart_rate} bpm." if resting_heart_rate > 0 else "- The alert suggests rhythm instability worth checking, but it is not a confirmed diagnosis by itself.",
+                "- The alert suggests rhythm instability worth checking, but it is not a confirmed diagnosis by itself." if resting_heart_rate > 0 else "",
+                "",
+                "**Possible Reasons**",
+                "- This could reflect atrial fibrillation or another rhythm issue, but it can also come from wearable signal noise or a temporary rhythm disturbance.",
+                "- The alert alone is not enough to determine the exact rhythm problem without symptoms and a formal ECG.",
+                "",
+                "**What To Do Now**",
+                "- Contact the older adult and ask about palpitations, dizziness, chest discomfort, shortness of breath, or near-fainting.",
+                "- Ask them to stop activity, sit down, rest, and repeat the reading if possible.",
+                "- If there is prior ECG history or medication information, keep it ready for whoever follows up.",
+                "",
+                "**When To Call Emergency Help**",
+                "- Call emergency help right away if the alert comes with fainting, severe shortness of breath, confusion, or ongoing chest pain.",
+                "- If repeated irregular rhythm alerts continue and the older adult cannot be reached, arrange urgent on-site confirmation.",
+            ]
+        ).replace("\n- \n", "\n")
+
+    if event_type == "temperature_alert":
+        if classification == "low_temperature":
+            return "\n".join(
+                [
+                    "**What This Means**",
+                    f"- The wearable suggests a low body temperature around {body_temperature:.1f}C.",
+                    "- Low temperature in an older adult can matter even when the cause is not yet clear.",
+                    "",
+                    "**Possible Reasons**",
+                    "- This can happen with cold environment exposure, poor intake, infection, or a general decline in condition.",
+                    "- Device error is also possible, so a repeat temperature check is important.",
+                    "",
+                    "**What To Do Now**",
+                    "- Contact the older adult, confirm their mental status, and ask whether they feel cold, weak, or shaky.",
+                    "- Repeat the temperature if possible and help them stay warm while arranging in-person follow-up if needed.",
+                    "",
+                    "**When To Call Emergency Help**",
+                    "- Call emergency help if there is confusion, extreme weakness, slowed breathing, or no one can reach the older adult.",
+                    "- If repeat checks still show low temperature, urgent in-person assessment is reasonable.",
+                ]
+            )
+        return "\n".join(
+            [
+                "**What This Means**",
+                f"- The wearable suggests a high body temperature around {body_temperature:.1f}C, which may reflect fever or an acute inflammatory process.",
+                "- Fever does not automatically mean severe illness, but in older adults it can come with dehydration or mental status changes more easily.",
+                "",
+                "**Possible Reasons**",
+                "- This could reflect a respiratory infection, urinary infection, another inflammatory issue, or sometimes environmental heat or a measurement error.",
+                "- Symptoms such as cough, chills, painful urination, or low fluid intake make a true fever more likely.",
+                "",
+                "**What To Do Now**",
+                "- Contact the older adult and ask about chills, cough, breathing changes, painful urination, weakness, or reduced drinking.",
+                "- Repeat the temperature, encourage fluids if appropriate, and arrange an in-person check if the older adult seems worse.",
+                "",
+                "**When To Call Emergency Help**",
+                "- Call emergency help if there is confusion, severe shortness of breath, persistent vomiting, or inability to get up.",
+                "- If the family cannot reach the older adult or the temperature stays very high on repeat checks, escalate quickly.",
+            ]
+        )
+
+    if event_type == "inactivity_alert":
+        return "\n".join(
+            [
+                "**What This Means**",
+                f"- The wearable detected about {inactivity_minutes} minutes without meaningful movement, which is beyond the alert threshold of about {threshold_minutes} minutes.",
+                "- This does not automatically mean an emergency, but it is worth checking if the older adult would not normally stay still that long.",
+                "",
+                "**Possible Reasons**",
+                "- This may simply reflect a nap, watching TV, taking the device off, or a tracking gap.",
+                "- It could also reflect a fall, acute illness, reduced consciousness, or the older adult being unable to get up.",
+                "",
+                "**What To Do Now**",
+                "- Contact the older adult and confirm whether they are awake, responding normally, and simply resting.",
+                "- If they live alone, ask a nearby family member, neighbor, or caregiver to check in person soon.",
+                "",
+                "**When To Call Emergency Help**",
+                "- Treat it as urgent if there is prolonged inactivity together with no response from the older adult.",
+                "- If an in-person check finds abnormal breathing, altered consciousness, or inability to get up, call emergency help immediately.",
+            ]
+        )
+
+    return "\n".join(
+        [
+            "**What This Means**",
+            "- HealthClaw detected a health-related alert that deserves caregiver attention.",
+            "- The alert alone is not enough to determine the exact cause without checking the older adult directly.",
+            "",
+            "**Possible Reasons**",
+            "- The signal may reflect activity, device noise, or a real physical problem.",
+            "- Symptoms, duration, and repeat measurements are all needed to judge risk more accurately.",
+            "",
+            "**What To Do Now**",
+            "- Contact the older adult soon and confirm they are awake, responsive, and not alone.",
+            "- Ask about chest discomfort, breathing changes, dizziness, pain, a fall, or any other obvious problem.",
+            "- If practical, repeat the relevant measurement and see whether it improves.",
+            "",
+            "**When To Call Emergency Help**",
+            "- Call emergency help if there is altered consciousness, major breathing trouble, chest pain, injury after a fall, or no response from the older adult.",
+            "- If alerts keep repeating together with clear symptoms, urgent in-person care is appropriate.",
+        ]
+    )
+
+
 def build_fallback_alert_explanation(alert):
+    if _alert_locale(alert) == "en":
+        return _build_fallback_alert_explanation_en(alert)
     event_type = str(alert.get("event_type", "external_alert") or "external_alert")
     details = alert.get("details") if isinstance(alert.get("details"), dict) else {}
     heart_rate = _coerce_int(details.get("heart_rate", alert.get("heart_rate")), 0)
@@ -533,7 +791,13 @@ def send_message(open_id, content, msg_type="text", use_card=False):
 def upload_image(image_path):
     from lark_oapi.api.im.v1 import CreateImageRequest, CreateImageRequestBody
 
-    with open(image_path, "rb") as image_file:
+    src = os.path.abspath(image_path)
+    stem, _ext = os.path.splitext(os.path.basename(src))
+    prepared_path = os.path.join(PROJECT_ROOT, "temp", f"{stem}_feishu.jpg")
+    with Image.open(src) as image:
+        image.convert("RGB").save(prepared_path, format="JPEG", quality=92, optimize=True)
+
+    with open(prepared_path, "rb") as image_file:
         body = CreateImageRequestBody.builder() \
             .image_type("message") \
             .image(image_file) \
@@ -616,6 +880,7 @@ def _extract_alert_location_text(alert):
 
 
 def _format_external_alert(alert, explanation=None, explanation_source="", explanation_pending=False):
+    locale = _alert_locale(alert)
     event_type = alert.get("event_type", "external_alert")
     sender_id = alert.get("sender_id", "unknown")
     timestamp = alert.get("timestamp", time.strftime("%Y-%m-%d %H:%M:%S"))
@@ -624,27 +889,44 @@ def _format_external_alert(alert, explanation=None, explanation_source="", expla
     details = alert.get("details")
     location_text = _extract_alert_location_text(alert)
 
-    lines = [
-        "**跨设备告警通知**",
-        f"事件类型: `{event_type}`",
-        f"来源设备: `{sender_id}`",
-        f"告警等级: `{severity}`",
-        f"时间: `{timestamp}`",
-    ]
+    if locale == "en":
+        lines = [
+            "**Cross-device Alert**",
+            f"Event type: `{event_type}`",
+            f"Source device: `{sender_id}`",
+            f"Severity: `{severity}`",
+            f"Time: `{timestamp}`",
+        ]
+    else:
+        lines = [
+            "**跨设备告警通知**",
+            f"事件类型: `{event_type}`",
+            f"来源设备: `{sender_id}`",
+            f"告警等级: `{severity}`",
+            f"时间: `{timestamp}`",
+        ]
     if location_text:
-        lines.append(f"定位: `{location_text}`")
+        lines.append(f"Location: `{location_text}`" if locale == "en" else f"定位: `{location_text}`")
     lines.extend(["", message])
     if explanation_pending:
-        lines.extend(["", "_HealthClaw 正在补充这条告警的含义解读，请稍候..._"])
+        lines.extend(
+            ["", "_HealthClaw is preparing an explanation for this alert. Please wait a moment..._"]
+            if locale == "en"
+            else ["", "_HealthClaw 正在补充这条告警的含义解读，请稍候..._"]
+        )
     elif explanation:
-        title = "**HealthClaw 解读**"
+        title = "**HealthClaw Interpretation**" if locale == "en" else "**HealthClaw 解读**"
         if explanation_source == "fallback_auth_invalid":
-            title = "**HealthClaw 基础解读（LLM 暂不可用）**"
+            title = "**HealthClaw Baseline Interpretation (LLM temporarily unavailable)**" if locale == "en" else "**HealthClaw 基础解读（LLM 暂不可用）**"
         elif explanation_source == "fallback":
-            title = "**HealthClaw 基础解读**"
+            title = "**HealthClaw Baseline Interpretation**" if locale == "en" else "**HealthClaw 基础解读**"
         lines.extend(["", title, explanation.strip()])
         if explanation_source == "fallback_auth_invalid":
-            lines.append("_当前已自动切换为规则增强解读，待 LLM 凭证恢复后会自动恢复实时生成。_")
+            lines.append(
+                "_HealthClaw has automatically switched to rule-enhanced fallback interpretation and will return to live LLM generation once credentials recover._"
+                if locale == "en"
+                else "_当前已自动切换为规则增强解读，待 LLM 凭证恢复后会自动恢复实时生成。_"
+            )
     if details:
         details_text = json.dumps(details, ensure_ascii=False, indent=2)
         lines.extend(["", f"```json\n{details_text}\n```"])
@@ -889,7 +1171,7 @@ def handle_command(open_id, cmd):
 
     elif cmd == "/help":
         send_message(open_id, (
-            "📖 MedicalClaw 飞书 Bot 命令:\n"
+            "📖 HealthClaw 飞书 Bot 命令:\n"
             "/stop — 停止当前任务\n"
             "/status — 查看运行状态\n"
             "/restore — 恢复上次对话历史\n"
@@ -1028,7 +1310,7 @@ class MessagePoller:
         """通过给用户发空消息获取 chat_id（实际用 list messages 接口发现）"""
         if open_id in self.known_chats:
             return self.known_chats[open_id]
-        msg_id = send_message(open_id, "🩺 MedicalClaw 已上线，可以开始对话！")
+        msg_id = send_message(open_id, _startup_online_text())
         if msg_id:
             try:
                 result = self._api_get(
@@ -1068,7 +1350,7 @@ class MessagePoller:
         """使用应用信息中的 owner_id 发现 P2P 会话"""
         try:
             result = self._api_get(
-                f'https://open.feishu.cn/open-apis/application/v6/applications/{APP_ID}?lang=zh_cn')
+                f'https://open.feishu.cn/open-apis/application/v6/applications/{APP_ID}?lang={_feishu_application_lang()}')
             owner_id = result.get('data', {}).get('app', {}).get('owner', {}).get('owner_id', '')
             if owner_id:
                 print(f"[飞书-Poll] 应用 Owner: {owner_id}")
@@ -1076,7 +1358,7 @@ class MessagePoller:
                 data_body = json.dumps({
                     'receive_id': owner_id,
                     'msg_type': 'text',
-                    'content': json.dumps({"text": "🩺 MedicalClaw 已上线（轮询模式），可以开始对话！"})
+                    'content': json.dumps({"text": _startup_online_text(polling=True)})
                 }).encode()
                 req = urllib.request.Request(
                     'https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=open_id',
@@ -1186,7 +1468,7 @@ def main():
     )
 
     print("=" * 50)
-    print("  🩺 Self-Evolving MedicalClaw — 飞书 Bot")
+    print("  🩺 Self-Evolving HealthClaw — 飞书 Bot")
     print(f"  App ID: {APP_ID}")
     print(f"  授权用户: {ALLOWED_USERS or '全部'}")
     print("  模式: WebSocket + 轮询回退")

--- a/ga.py
+++ b/ga.py
@@ -1223,59 +1223,6 @@ class GenericAgentHandler(BaseHandler):
 
     def next_prompt_patcher(self, next_prompt, outcome, turn):
         self._current_turn = turn
-        # 每轮都追加输出语言提示；优先尊重用户显式要求（如 answer in Chinese）。
-        q = ""
-        for line in reversed(self.history_info or []):
-            if line.startswith("[USER]:"):
-                q = line[len("[USER]:") :].strip()
-                break
-        if q:
-            ql = q.lower()
-            lang = None
-            zh_override_markers = (
-                "answer in chinese",
-                "reply in chinese",
-                "respond in chinese",
-                "in chinese",
-                "请用中文",
-                "用中文回答",
-                "中文回答",
-                "中文输出",
-            )
-            en_override_markers = (
-                "answer in english",
-                "reply in english",
-                "respond in english",
-                "in english",
-                "请用英文",
-                "用英文回答",
-                "英文回答",
-                "英文输出",
-            )
-            if any(m in ql for m in zh_override_markers):
-                lang = "zh"
-            elif any(m in ql for m in en_override_markers):
-                lang = "en"
-            else:
-                cjk_count = len(re.findall(r"[\u4e00-\u9fff]", q))
-                en_word_count = len(re.findall(r"\b[a-zA-Z]{2,}\b", q))
-                if en_word_count >= 3 and en_word_count > cjk_count:
-                    lang = "en"
-                elif cjk_count >= 2 and cjk_count >= en_word_count:
-                    lang = "zh"
-
-            if lang == "en":
-                next_prompt += (
-                    "\n\n[System — Output Language]\n"
-                    "Respond in English for this turn.\n"
-                    "If your draft is not in English, rewrite it in English before final output."
-                )
-            elif lang == "zh":
-                next_prompt += (
-                    "\n\n[System — 输出语言]\n"
-                    "本轮请使用中文回答。\n"
-                    "若草稿不是中文，请在输出前改写为中文。"
-                )
 
         failure_hint = self.tracker.get_failure_summary()
         if failure_hint and turn % 3 == 0:

--- a/meal_plan_service.py
+++ b/meal_plan_service.py
@@ -204,14 +204,153 @@ def _phone_ready():
     return ok
 
 
+def _dismiss_address_panel_if_needed():
+    nodes, _summary = phone_control.ui_dump(clickable_only=False)
+    if not nodes:
+        return False
+
+    full_text = " ".join(
+        " ".join(
+            [
+                str(node.get("text", "") or "").strip(),
+                str(node.get("description", "") or "").strip(),
+                str(node.get("id", "") or "").strip(),
+            ]
+        )
+        for node in nodes
+    )
+    panel_markers = ["当前指定地址", "指定地址", "附近地址", "我的地址", "修改地址", "重置", "完成"]
+    if not any(marker in full_text for marker in panel_markers):
+        return False
+
+    complete_candidates = []
+    for node in nodes:
+        text = str(node.get("text", "") or "").strip()
+        desc = str(node.get("description", "") or "").strip()
+        if text == "完成" or desc == "完成":
+            complete_candidates.append(node)
+    if not complete_candidates:
+        return False
+
+    target = sorted(complete_candidates, key=lambda node: int(node.get("cy", 0) or 0), reverse=True)[0]
+    point = (int(target.get("cx", 0)), int(target.get("cy", 0)))
+    if point == (0, 0):
+        return False
+    _tap(point)
+    time.sleep(2.5)
+    return True
+
+
+def _stabilize_search_surface():
+    """Best-effort cleanup for overlays that can cover search/result content."""
+    _handle_known_overlays()
+    changed = False
+    for _ in range(2):
+        if _dismiss_address_panel_if_needed():
+            changed = True
+            time.sleep(1.5)
+            _handle_known_overlays()
+    return changed
+
+
+def _tap_homepage_search_entry():
+    nodes, _summary = phone_control.ui_dump(clickable_only=False)
+    preferred_ids = {
+        "com.sankuai.meituan:id/search_layout_area",
+        "com.sankuai.meituan:id/search_button",
+    }
+    candidates = []
+    for node in nodes:
+        node_id = str(node.get("id", "") or "").strip()
+        text = str(node.get("text", "") or "").strip()
+        desc = str(node.get("description", "") or "").strip()
+        if node_id in preferred_ids:
+            candidates.append(node)
+            continue
+        if "搜索" in text or "搜索" in desc:
+            candidates.append(node)
+    if not candidates:
+        return False
+
+    def _score(node):
+        node_id = str(node.get("id", "") or "").strip()
+        text = str(node.get("text", "") or "").strip()
+        desc = str(node.get("description", "") or "").strip()
+        score = 0
+        if node_id == "com.sankuai.meituan:id/search_layout_area":
+            score += 6
+        elif node_id == "com.sankuai.meituan:id/search_button":
+            score += 4
+        if "搜索" in text:
+            score += 2
+        if "搜索" in desc:
+            score += 2
+        return score
+
+    target = sorted(candidates, key=_score, reverse=True)[0]
+    point = (int(target.get("cx", 0)), int(target.get("cy", 0)))
+    if point == (0, 0):
+        return False
+    _tap(point)
+    time.sleep(2.5)
+    return True
+
+
+def _tap_search_submit_button():
+    nodes, _summary = phone_control.ui_dump(clickable_only=False)
+    candidates = []
+    for node in nodes:
+        text = str(node.get("text", "") or "").strip()
+        desc = str(node.get("description", "") or "").strip()
+        node_id = str(node.get("id", "") or "").strip()
+        cy = int(node.get("cy", 0) or 0)
+        if cy and cy > 420:
+            continue
+        if node_id == "com.sankuai.meituan:id/search_button":
+            candidates.append(node)
+            continue
+        if text == "搜索" or desc == "搜索":
+            candidates.append(node)
+    if not candidates:
+        return False
+
+    def _score(node):
+        score = 0
+        node_id = str(node.get("id", "") or "").strip()
+        text = str(node.get("text", "") or "").strip()
+        desc = str(node.get("description", "") or "").strip()
+        if node_id == "com.sankuai.meituan:id/search_button":
+            score += 8
+        if text == "搜索":
+            score += 4
+        if desc == "搜索":
+            score += 2
+        return score
+
+    target = sorted(candidates, key=_score, reverse=True)[0]
+    point = (int(target.get("cx", 0)), int(target.get("cy", 0)))
+    if point == (0, 0):
+        return False
+    _tap(point)
+    time.sleep(2.5)
+    return True
+
+
 def _open_search_page():
     _ensure_adb_env()
     phone_control.press_key("home")
     time.sleep(1)
     _run_adb("shell", "am", "start", "-W", "-n", MEITUAN_SEARCH_ACTIVITY, timeout=25)
     time.sleep(1.2)
-    _handle_known_overlays()
+    _stabilize_search_surface()
     activity = _wait_for_activity([".search.home.SearchActivity", ".search.result.SearchResultActivity"], timeout=20)
+    if ".search.home.SearchActivity" not in activity and ".search.result.SearchResultActivity" not in activity:
+        current = _current_activity()
+        if MEITUAN_MAIN_ACTIVITY in current and _tap_homepage_search_entry():
+            _stabilize_search_surface()
+            activity = _wait_for_activity([".search.home.SearchActivity", ".search.result.SearchResultActivity"], timeout=10)
+    if _stabilize_search_surface():
+        activity = _wait_for_activity([".search.home.SearchActivity", ".search.result.SearchResultActivity"], timeout=10)
     if UPGRADE_DIALOG_ACTIVITY in activity:
         _dismiss_upgrade_dialog_if_needed()
         activity = _wait_for_activity([".search.home.SearchActivity", ".search.result.SearchResultActivity"], timeout=10)
@@ -248,7 +387,13 @@ def _price_to_float(text):
 
 def _query_terms(query):
     known_terms = ["轻食", "沙拉", "鸡胸", "鸡胸肉", "豆浆", "三明治", "便当", "减脂", "低脂", "全麦"]
-    return [term for term in known_terms if term in query]
+    found = [term for term in known_terms if term in query]
+    if found:
+        return found
+    text = str(query or "").strip()
+    if " " in text:
+        return [part.strip() for part in text.split() if len(part.strip()) >= 2]
+    return [text] if len(text) >= 2 else []
 
 
 def _is_real_suggestion(text, query):
@@ -257,9 +402,35 @@ def _is_real_suggestion(text, query):
         return False
     if clean.endswith("按钮") or clean.startswith("复旦大学("):
         return False
-    if any(token in clean for token in ["好评榜", "热销榜", "门店销量", "新客", "配送", "下单", "评分", "接受预订", "明天", "清除历史记录"]):
+    if any(
+        token in clean
+        for token in [
+            "好评榜",
+            "热销榜",
+            "门店销量",
+            "新客",
+            "配送",
+            "下单",
+            "评分",
+            "接受预订",
+            "明天",
+            "清除历史记录",
+            "演唱会",
+            "抢票",
+            "上线",
+            "商圈",
+            "当前指定地址",
+            "附近地址",
+            "我的地址",
+            "修改地址",
+            "完成",
+            "重置",
+            "地址",
+        ]
+    ):
         return False
-    if query and not any(ch in clean for ch in query if ch.strip()):
+    query_terms = _query_terms(query)
+    if query_terms and not any(term in clean for term in query_terms):
         return False
     return len(clean) >= 2
 
@@ -306,9 +477,17 @@ def _score_suggestion(candidate, query):
 
 
 def _is_safe_item_to_add(item_name, store_name, query, item_price):
-    aggregate = f"{item_name} {store_name} {query}"
+    aggregate = f"{item_name} {store_name}"
     query_terms = _query_terms(query)
-    if query_terms and not any(term in aggregate for term in query_terms):
+    matched_terms = [term for term in query_terms if term and term in aggregate]
+    if query_terms and not matched_terms:
+        return False
+    if any(term in query for term in ["沙拉", "轻食"]):
+        if not any(token in aggregate for token in ["沙拉", "轻食", "健康餐"]):
+            return False
+        if any(token in aggregate for token in ["牛排", "牛扒", "面包", "蛋糕", "咖啡", "豆浆夜市", "超市"]):
+            return False
+    if "鸡胸" in query and "鸡胸" not in aggregate:
         return False
     price_value = _price_to_float(item_price)
     if price_value and price_value > 50:
@@ -322,7 +501,31 @@ def _is_result_store_box(box):
         return False
     if box["top"] < 500 or box["top"] > 1700:
         return False
-    if any(key in text for key in ["月售", "分钟", "km", "点评", "起送", "配送", "营业", "红包", "领券", "图片热量", "收藏", "价格", "￥", "¥", "休息"]):
+    if any(
+        key in text
+        for key in [
+            "月售",
+            "分钟",
+            "km",
+            "点评",
+            "起送",
+            "配送",
+            "营业",
+            "红包",
+            "领券",
+            "图片热量",
+            "收藏",
+            "价格",
+            "￥",
+            "¥",
+            "休息",
+            "人气榜",
+            "好评榜",
+            "热销榜",
+            "第",
+            "名>",
+        ]
+    ):
         return False
     if len(text) < 4 or text.startswith("复旦大学"):
         return False
@@ -379,21 +582,31 @@ def _extract_result_cards(ocr_boxes, limit=3):
 def _score_result_card(card, query):
     aggregate = f"{card.get('store_name', '')} {card.get('block_text', '')}"
     score = 0
-    for term in _query_terms(query):
+    query_terms = _query_terms(query)
+    for term in query_terms:
         if term in card.get("store_name", ""):
             score += 5
         if term in aggregate:
             score += 2
     if "轻食" in aggregate or "沙拉" in aggregate:
         score += 2
+    if "健康餐" in aggregate:
+        score += 2
+    if "鸡胸" in aggregate or "鸡肉" in aggregate:
+        score += 2
     if "便利店" in card.get("store_name", ""):
         score -= 2
+    if any(term in query for term in ["沙拉", "轻食"]):
+        if not any(token in aggregate for token in ["沙拉", "轻食", "健康餐"]):
+            score -= 6
+        if any(token in aggregate for token in ["牛排", "牛扒", "面包", "蛋糕", "咖啡", "豆浆夜市", "超市"]):
+            score -= 8
     return score
 
 
 def _extract_addable_items(ocr_boxes, limit=3):
     plus_boxes = [b for b in ocr_boxes if b["text"] == "+" and b["top"] > 1000]
-    spec_boxes = [b for b in ocr_boxes if "选规格" in b["text"] and b["top"] > 1800]
+    spec_boxes = [b for b in ocr_boxes if ("选规格" in b["text"] or "选套餐" in b["text"]) and b["top"] > 1800]
     items = []
     action_boxes = [("add", box) for box in plus_boxes] + [("select_spec", box) for box in spec_boxes]
     for action_type, plus in action_boxes:
@@ -441,6 +654,16 @@ def _extract_addable_items(ocr_boxes, limit=3):
     return items
 
 
+def _scroll_merchant_for_addable_items():
+    """Merchant pages often place the + button slightly below the first viewport."""
+    res, _, _ = _run_adb("shell", "wm", "size")
+    m = re.search(r"(\d+)x(\d+)", res)
+    if m:
+        w, h = int(m.group(1)), int(m.group(2))
+        return phone_control.swipe(w // 2, int(h * 0.78), w // 2, int(h * 0.58), 350)
+    return phone_control.swipe(540, 1820, 540, 1350, 350)
+
+
 def _extract_cart_summary(ocr_boxes):
     total_price = ""
     cart_cta = ""
@@ -474,6 +697,10 @@ def _best_effort_submit_search():
         phone_control.press_key("enter")
         time.sleep(2.5)
         activity = _current_activity()
+    if ".search.result.SearchResultActivity" not in activity and _tap_search_submit_button():
+        activity = _current_activity()
+    if _stabilize_search_surface():
+        activity = _current_activity()
     return activity
 
 
@@ -502,6 +729,9 @@ def search_food_suggestions(query, limit=5):
         "searched_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
     }
     result_activity = _best_effort_submit_search()
+    time.sleep(1.5)
+    _stabilize_search_surface()
+    result_activity = _current_activity()
     screenshot_path = _capture_screenshot("meituan_search_result")
     return {**base, "result_activity": result_activity, "screenshot_path": screenshot_path}
 
@@ -523,6 +753,9 @@ def search_and_add_best_item(query, limit=5):
     result_activity = _current_activity()
     if ".search.result.SearchResultActivity" not in result_activity:
         result_activity = _best_effort_submit_search()
+    time.sleep(1.5)
+    _stabilize_search_surface()
+    result_activity = _current_activity()
     result_screenshot = _capture_screenshot("meituan_search_result")
     result_boxes = _ocr_boxes(result_screenshot) if result_screenshot and os.path.exists(result_screenshot) else []
     result_cards = _extract_result_cards(result_boxes, limit=limit)
@@ -536,15 +769,26 @@ def search_and_add_best_item(query, limit=5):
         merchant_screenshot = _capture_screenshot("meituan_merchant_page")
         merchant_boxes = _ocr_boxes(merchant_screenshot)
         addable_items = _extract_addable_items(merchant_boxes, limit=3)
+        if not addable_items:
+            _scroll_merchant_for_addable_items()
+            time.sleep(2.0)
+            merchant_screenshot = _capture_screenshot("meituan_merchant_page")
+            merchant_boxes = _ocr_boxes(merchant_screenshot)
+            addable_items = _extract_addable_items(merchant_boxes, limit=3)
         if addable_items:
             selected = addable_items[0]
             if selected.get("action_type") == "select_spec":
+                _tap(selected["add_button"])
+                time.sleep(2.5)
+                spec_screenshot = _capture_screenshot("meituan_spec_selection")
                 cart_action = {
                     "status": "needs_spec_selection",
                     "store_name": first_card["store_name"],
                     "item_name": selected["item_name"],
                     "item_price": selected["price"],
                     "merchant_screenshot": merchant_screenshot,
+                    "cart_screenshot": spec_screenshot,
+                    "spec_panel_opened": True,
                 }
             elif _is_safe_item_to_add(selected["item_name"], first_card["store_name"], query, selected["price"]):
                 _tap(selected["add_button"])
@@ -589,56 +833,106 @@ def search_and_add_best_item(query, limit=5):
 
 
 DEFAULT_MEAL_SCHEDULE = {
-    "breakfast": {"meal_time": "08:00", "push_lead_minutes": 60, "label": "早餐"},
-    "lunch": {"meal_time": "12:00", "push_lead_minutes": 60, "label": "午餐"},
-    "dinner": {"meal_time": "18:00", "push_lead_minutes": 60, "label": "晚餐"},
+    "breakfast": {"meal_time": "08:00", "push_lead_minutes": 60, "label": "早餐", "label_en": "Breakfast"},
+    "lunch": {"meal_time": "12:00", "push_lead_minutes": 60, "label": "午餐", "label_en": "Lunch"},
+    "dinner": {"meal_time": "18:00", "push_lead_minutes": 60, "label": "晚餐", "label_en": "Dinner"},
 }
 
 
 GOAL_CONFIGS = {
     "weight_loss": {
         "label": "减脂",
+        "label_en": "Weight loss",
         "daily_calories": 1450,
         "meal_targets": {"breakfast": (300, 380), "lunch": (450, 580), "dinner": (400, 520)},
         "focus_tags": ["high_protein", "vegetable_rich", "light", "low_sugar"],
         "avoid_tags": ["fried", "sugary", "heavy_sauce"],
         "summary": "控制总热量、优先高蛋白和高蔬菜比例，帮助稳定减脂。",
+        "summary_en": "Control total calories with higher protein and more vegetables to support steady fat loss.",
     },
     "glucose_control": {
         "label": "控糖",
+        "label_en": "Glucose control",
         "daily_calories": 1550,
         "meal_targets": {"breakfast": (320, 400), "lunch": (480, 600), "dinner": (420, 520)},
         "focus_tags": ["low_sugar", "whole_grain", "high_fiber", "high_protein"],
         "avoid_tags": ["sugary", "refined_carb", "sweet_drink"],
         "summary": "优先低糖、粗粮和纤维，减少餐后血糖波动。",
+        "summary_en": "Prioritize lower sugar, whole grains, and fiber to reduce post-meal glucose swings.",
     },
     "heart_healthy": {
         "label": "心血管友好",
+        "label_en": "Heart-healthy",
         "daily_calories": 1550,
         "meal_targets": {"breakfast": (320, 400), "lunch": (470, 600), "dinner": (420, 520)},
         "focus_tags": ["low_sodium", "high_protein", "vegetable_rich", "soup"],
         "avoid_tags": ["fried", "high_sodium", "processed_meat"],
         "summary": "关注低盐、低油和稳定能量摄入，适合血压或心血管风险管理。",
+        "summary_en": "Emphasize lower sodium, lighter cooking, and steady energy intake for blood pressure or cardiovascular risk management.",
     },
     "balanced": {
         "label": "均衡饮食",
+        "label_en": "Balanced nutrition",
         "daily_calories": 1650,
         "meal_targets": {"breakfast": (320, 420), "lunch": (500, 650), "dinner": (450, 580)},
         "focus_tags": ["balanced", "high_protein", "vegetable_rich"],
         "avoid_tags": ["fried", "heavy_sauce"],
         "summary": "以均衡、可长期坚持为主，兼顾蛋白质、蔬菜和主食结构。",
+        "summary_en": "Focus on a balanced pattern that is sustainable long term, with protein, vegetables, and structured carbs.",
     },
 }
 
 
 DAY_THEME_ROTATION = [
-    {"name": "高蛋白轻负担日", "extra_tags": ["high_protein", "light"], "note": "优先鸡胸肉、鱼虾、豆制品和蔬菜。"},
-    {"name": "低糖稳能量日", "extra_tags": ["low_sugar", "whole_grain"], "note": "主食以全麦和粗粮为主，减少精制碳水。"},
-    {"name": "高纤维蔬菜日", "extra_tags": ["high_fiber", "vegetable_rich"], "note": "增加深色蔬菜和豆类摄入。"},
-    {"name": "低盐清爽日", "extra_tags": ["low_sodium", "soup"], "note": "适合控制钠摄入，避免重口味。"},
-    {"name": "鱼类优先日", "extra_tags": ["seafood", "light"], "note": "用鱼虾类替代部分红肉，减轻油腻负担。"},
-    {"name": "温和恢复日", "extra_tags": ["comfort", "soup"], "note": "适合忙碌后恢复，选择更好消化的组合。"},
-    {"name": "规律收口日", "extra_tags": ["balanced", "vegetable_rich"], "note": "三餐保持规律，避免临睡前过量进食。"},
+    {
+        "name": "高蛋白轻负担日",
+        "name_en": "High-protein light day",
+        "extra_tags": ["high_protein", "light"],
+        "note": "优先鸡胸肉、鱼虾、豆制品和蔬菜。",
+        "note_en": "Prioritize chicken breast, fish, shrimp, tofu, and vegetables.",
+    },
+    {
+        "name": "低糖稳能量日",
+        "name_en": "Low-sugar steady-energy day",
+        "extra_tags": ["low_sugar", "whole_grain"],
+        "note": "主食以全麦和粗粮为主，减少精制碳水。",
+        "note_en": "Use whole grains and coarse grains as the main carbs and reduce refined starches.",
+    },
+    {
+        "name": "高纤维蔬菜日",
+        "name_en": "High-fiber vegetable day",
+        "extra_tags": ["high_fiber", "vegetable_rich"],
+        "note": "增加深色蔬菜和豆类摄入。",
+        "note_en": "Increase dark leafy vegetables and legumes.",
+    },
+    {
+        "name": "低盐清爽日",
+        "name_en": "Low-sodium light day",
+        "extra_tags": ["low_sodium", "soup"],
+        "note": "适合控制钠摄入，避免重口味。",
+        "note_en": "Keep sodium lower and avoid heavy seasoning.",
+    },
+    {
+        "name": "鱼类优先日",
+        "name_en": "Fish-first day",
+        "extra_tags": ["seafood", "light"],
+        "note": "用鱼虾类替代部分红肉，减轻油腻负担。",
+        "note_en": "Swap some red meat for fish or shrimp to keep meals lighter.",
+    },
+    {
+        "name": "温和恢复日",
+        "name_en": "Gentle recovery day",
+        "extra_tags": ["comfort", "soup"],
+        "note": "适合忙碌后恢复，选择更好消化的组合。",
+        "note_en": "Use easier-to-digest combinations after a busy stretch.",
+    },
+    {
+        "name": "规律收口日",
+        "name_en": "Structured rhythm day",
+        "extra_tags": ["balanced", "vegetable_rich"],
+        "note": "三餐保持规律，避免临睡前过量进食。",
+        "note_en": "Keep meals regular and avoid overeating late at night.",
+    },
 ]
 
 
@@ -862,6 +1156,86 @@ def _recommendation_source_label(source):
     return source or "unknown"
 
 
+def _normalize_locale(locale):
+    return "en" if str(locale or "").strip().lower().startswith("en") else "zh"
+
+
+def _translate_constraint_note(note, locale):
+    if _normalize_locale(locale) != "en":
+        return note
+    mapping = {
+        "已避开用户已知过敏原。": "Known allergens are already excluded.",
+        "结合血糖/糖代谢风险，额外强调低糖和粗粮结构。": "Added stronger low-sugar and whole-grain guidance for glucose or metabolic risk.",
+        "结合血压风险，额外强调低盐和少加工。": "Added stronger low-sodium and low-processed-food guidance for blood pressure risk.",
+        "当前按通用健康约束生成，后续可继续根据你的偏好微调。": "Built with general health constraints for now, and it can be refined later around your preferences.",
+    }
+    return mapping.get(note, note)
+
+
+def _recommendation_source_note_for_locale(source, locale):
+    if _normalize_locale(locale) != "en":
+        return _recommendation_source_note(source)
+    if source == "meituan_phone_live_search":
+        return "The demo currently prioritizes the real phone-based Meituan search chain, and falls back to local candidate data only when the phone chain is unavailable."
+    if source == "meituan_demo_catalog":
+        return "The demo is currently using the local candidate catalog by default and can switch to real Meituan search once the phone chain is connected."
+    if source == "meituan_phone_suggestion":
+        return "Recommendations currently come from real phone-based Meituan search suggestions."
+    return f"Current recommendation source: {source}"
+
+
+def _recommendation_source_label_for_locale(source, locale):
+    if _normalize_locale(locale) != "en":
+        return _recommendation_source_label(source)
+    if source == "meituan_phone_live_search":
+        return "Real phone Meituan search first"
+    if source == "meituan_demo_catalog":
+        return "Local demo candidate catalog"
+    if source == "meituan_phone_suggestion":
+        return "Real phone Meituan suggestions"
+    return source or "unknown"
+
+
+def _meal_label_for_locale(meal_key, payload, locale):
+    if _normalize_locale(locale) == "en":
+        return str(
+            (payload or {}).get("label_en")
+            or (payload or {}).get("meal_label_en")
+            or DEFAULT_MEAL_SCHEDULE.get(meal_key, {}).get("label_en")
+            or meal_key.title()
+        )
+    return str(
+        (payload or {}).get("label")
+        or (payload or {}).get("meal_label")
+        or DEFAULT_MEAL_SCHEDULE.get(meal_key, {}).get("label")
+        or meal_key
+    )
+
+
+def _theme_name_for_locale(day_plan, locale):
+    if _normalize_locale(locale) == "en":
+        return str((day_plan or {}).get("theme_en") or (day_plan or {}).get("theme") or "")
+    return str((day_plan or {}).get("theme") or "")
+
+
+def _goal_note_for_locale(meal_spec, locale):
+    if _normalize_locale(locale) == "en":
+        return str((meal_spec or {}).get("goal_note_en") or (meal_spec or {}).get("goal_note") or "")
+    return str((meal_spec or {}).get("goal_note") or "")
+
+
+def _query_for_locale(meal_spec, locale):
+    if _normalize_locale(locale) == "en":
+        return str((meal_spec or {}).get("query_en_display") or (meal_spec or {}).get("phone_query") or (meal_spec or {}).get("query") or "")
+    return str((meal_spec or {}).get("query") or "")
+
+
+def _candidate_reason_for_locale(candidate, locale, default_zh, default_en):
+    if _normalize_locale(locale) == "en":
+        return str((candidate or {}).get("reason_en") or default_en)
+    return str((candidate or {}).get("reason") or default_zh)
+
+
 def _safe_float(value, default=0.0):
     try:
         return float(value)
@@ -882,6 +1256,16 @@ def _parse_clock(text, default_clock):
     text = text.strip()
     if not text:
         return default_clock
+    am_pm_match = re.match(r"(?i)(\d{1,2})(?::(\d{1,2}))?\s*(am|pm)", text)
+    if am_pm_match:
+        hour = int(am_pm_match.group(1))
+        minute = int(am_pm_match.group(2) or 0)
+        meridiem = am_pm_match.group(3).lower()
+        if meridiem == "pm" and hour < 12:
+            hour += 12
+        if meridiem == "am" and hour == 12:
+            hour = 0
+        return f"{hour:02d}:{minute:02d}"
     if ":" in text:
         parts = text.split(":")
         try:
@@ -927,11 +1311,11 @@ class MealPlanService:
     def parse_request(self, text):
         lowered = str(text or "").lower()
         goal = "balanced"
-        if any(word in lowered for word in ["减肥", "瘦身", "减脂", "控制体重"]):
+        if any(word in lowered for word in ["减肥", "瘦身", "减脂", "控制体重", "lose weight", "weight loss", "fat loss", "slim down"]):
             goal = "weight_loss"
-        elif any(word in lowered for word in ["控糖", "血糖", "糖尿病", "少糖"]):
+        elif any(word in lowered for word in ["控糖", "血糖", "糖尿病", "少糖", "glucose", "blood sugar", "diabetes", "low sugar"]):
             goal = "glucose_control"
-        elif any(word in lowered for word in ["血压", "低盐", "心脏", "心血管"]):
+        elif any(word in lowered for word in ["血压", "低盐", "心脏", "心血管", "blood pressure", "heart", "cardio", "low sodium"]):
             goal = "heart_healthy"
 
         meal_schedule = copy.deepcopy(DEFAULT_MEAL_SCHEDULE)
@@ -943,6 +1327,15 @@ class MealPlanService:
         )
         meal_schedule["dinner"]["meal_time"] = _extract_meal_time(
             text, ["晚餐", "晚饭", "晚上的饭", "晚上"], meal_schedule["dinner"]["meal_time"]
+        )
+        meal_schedule["breakfast"]["meal_time"] = _extract_meal_time(
+            text, ["breakfast", "morning"], meal_schedule["breakfast"]["meal_time"]
+        )
+        meal_schedule["lunch"]["meal_time"] = _extract_meal_time(
+            text, ["lunch", "noon"], meal_schedule["lunch"]["meal_time"]
+        )
+        meal_schedule["dinner"]["meal_time"] = _extract_meal_time(
+            text, ["dinner", "supper", "evening"], meal_schedule["dinner"]["meal_time"]
         )
         for meal_key, schedule in meal_schedule.items():
             schedule["push_time"] = _compute_push_time(schedule["meal_time"], schedule["push_lead_minutes"])
@@ -1006,6 +1399,7 @@ class MealPlanService:
         theme = DAY_THEME_ROTATION[day_index % len(DAY_THEME_ROTATION)]
         meals = {}
         for meal_key, label in [("breakfast", "早餐"), ("lunch", "午餐"), ("dinner", "晚餐")]:
+            meal_label_en = DEFAULT_MEAL_SCHEDULE[meal_key]["label_en"]
             calorie_min, calorie_max = goal_config["meal_targets"][meal_key]
             preferred_tags = list(goal_config["focus_tags"]) + list(theme["extra_tags"])
             if meal_key == "breakfast":
@@ -1027,25 +1421,34 @@ class MealPlanService:
             if "whole_grain" in preferred_tags:
                 query += " 粗粮"
             phone_query = self._build_phone_search_query(goal_config["label"], meal_key, preferred_tags)
+            query_en_display = f"Meituan {goal_config['label_en']} {meal_label_en} / high protein / light"
+            if "low_sugar" in preferred_tags:
+                query_en_display += " / low sugar"
+            if "whole_grain" in preferred_tags:
+                query_en_display += " / whole grain"
             meals[meal_key] = {
                 "meal_label": label,
+                "meal_label_en": meal_label_en,
                 "target_calories": [calorie_min, calorie_max],
                 "preferred_tags": sorted(set(preferred_tags)),
                 "avoid_tags": sorted(set(avoid_tags)),
                 "query": query.strip(),
+                "query_en_display": query_en_display,
                 "phone_query": phone_query,
                 "goal_note": theme["note"],
+                "goal_note_en": theme["note_en"],
             }
         return {
             "date": plan_date.strftime("%Y-%m-%d"),
             "theme": theme["name"],
+            "theme_en": theme["name_en"],
             "meals": meals,
         }
 
     def _build_phone_search_query(self, goal_label, meal_key, preferred_tags):
         if meal_key == "breakfast":
             if "low_sugar" in preferred_tags:
-                return "无糖豆浆 全麦三明治 早餐"
+                return "无糖豆浆全麦三明治"
             return "高蛋白轻食早餐"
         if meal_key == "lunch":
             if "whole_grain" in preferred_tags:
@@ -1054,10 +1457,10 @@ class MealPlanService:
                 return "清淡鸡胸肉便当 午餐"
             return "鸡胸肉蔬菜沙拉 午餐"
         if "seafood" in preferred_tags:
-            return "三文鱼沙拉 晚餐"
+            return "三文鱼沙拉"
         if "comfort" in preferred_tags:
-            return "低脂鸡肉沙拉 晚餐"
-        return "轻食减脂餐晚餐"
+            return "鸡胸肉蔬菜沙拉"
+        return "轻食鸡肉沙拉"
 
     def create_plan(self, open_id, text):
         parsed = self.parse_request(text)
@@ -1079,7 +1482,9 @@ class MealPlanService:
             "request_text": parsed["request_text"],
             "goal": goal_key,
             "goal_label": goal_config["label"],
+            "goal_label_en": goal_config["label_en"],
             "summary": goal_config["summary"],
+            "summary_en": goal_config["summary_en"],
             "created_at": datetime.now().strftime("%Y-%m-%d %H:%M"),
             "updated_at": datetime.now().strftime("%Y-%m-%d %H:%M"),
             "start_date": start_date.strftime("%Y-%m-%d"),
@@ -1181,6 +1586,19 @@ class MealPlanService:
             reasons.append("整体更接近今天这顿“高蛋白、清淡、少油少负担”的方向")
         return "；".join(reasons)
 
+    def _build_candidate_reason_en(self, meal_spec, item_name, store_name):
+        reasons = []
+        text = f"{item_name} {store_name}"
+        if any(token in text for token in ["鸡胸", "牛肉", "鱼", "虾", "豆浆", "鸡蛋", "三文鱼", "豆腐"]):
+            reasons.append("Leans higher in protein, which matches this meal's weight-management goal")
+        if any(token in text for token in ["沙拉", "蔬菜", "轻食", "健康餐"]):
+            reasons.append("Usually comes with a higher vegetable ratio and feels lighter overall")
+        if any(token in text for token in ["全麦", "糙米", "杂粮"]):
+            reasons.append("Has a steadier carb structure that supports calorie control and satiety")
+        if not reasons:
+            reasons.append("Overall it stays closer to today's high-protein, lighter, lower-burden direction")
+        return "; ".join(reasons)
+
     def _build_display_candidates(self, meal_spec, candidates, result_cards, cart_action):
         display = []
         used_items = set()
@@ -1193,6 +1611,7 @@ class MealPlanService:
                     "store_name": cart_action.get("store_name", ""),
                     "price": cart_action.get("item_price", "") or "待店内确认",
                     "reason": self._build_candidate_reason(meal_spec, item_name, cart_action.get("store_name", "")),
+                    "reason_en": self._build_candidate_reason_en(meal_spec, item_name, cart_action.get("store_name", "")),
                 }
             )
             used_items.add(item_name)
@@ -1208,6 +1627,7 @@ class MealPlanService:
                     "store_name": store_name,
                     "price": "待店内确认",
                     "reason": self._build_candidate_reason(meal_spec, item_name, store_name),
+                    "reason_en": self._build_candidate_reason_en(meal_spec, item_name, store_name),
                 }
             )
             used_items.add(item_name)
@@ -1225,6 +1645,7 @@ class MealPlanService:
                     "store_name": store_name,
                     "price": candidate.get("price", "") or "待店内确认",
                     "reason": self._build_candidate_reason(meal_spec, item_name, store_name),
+                    "reason_en": self._build_candidate_reason_en(meal_spec, item_name, store_name),
                 }
             )
             used_items.add(item_name)
@@ -1253,19 +1674,26 @@ class MealPlanService:
         results = []
         for score, candidate in ranked[:limit]:
             reason_bits = []
+            reason_bits_en = []
             if "high_protein" in candidate.get("tags", []):
                 reason_bits.append("蛋白质更高")
+                reason_bits_en.append("higher protein")
             if "low_sugar" in candidate.get("tags", []):
                 reason_bits.append("更适合控糖")
+                reason_bits_en.append("better for glucose control")
             if "vegetable_rich" in candidate.get("tags", []):
                 reason_bits.append("蔬菜比例较高")
+                reason_bits_en.append("more vegetables")
             if "low_sodium" in candidate.get("tags", []):
                 reason_bits.append("更偏低盐")
+                reason_bits_en.append("lower sodium")
             if "whole_grain" in candidate.get("tags", []):
                 reason_bits.append("含粗粮/全麦")
+                reason_bits_en.append("includes whole grains")
             enriched = copy.deepcopy(candidate)
             enriched["match_score"] = score
             enriched["match_reason"] = "、".join(reason_bits) or "整体较符合当前这顿的目标"
+            enriched["match_reason_en"] = ", ".join(reason_bits_en) or "Overall a better fit for this meal's current goal"
             results.append(enriched)
         return results
 
@@ -1297,6 +1725,7 @@ class MealPlanService:
                         "store_name": item.get("store_name", ""),
                         "price": item.get("price", "") or "待店内确认",
                         "reason": item.get("match_reason", "整体较符合当前这顿目标"),
+                        "reason_en": item.get("match_reason_en", "Overall a better fit for this meal's current goal"),
                     }
                     for item in fallback_candidates[:limit]
                 ],
@@ -1362,6 +1791,7 @@ class MealPlanService:
                     "store_name": item.get("store_name", ""),
                     "price": item.get("price", "") or "待店内确认",
                     "reason": item.get("match_reason", "整体较符合当前这顿目标"),
+                    "reason_en": item.get("match_reason_en", "Overall a better fit for this meal's current goal"),
                 }
                     for item in fallback_candidates[:limit]
             ],
@@ -1371,24 +1801,45 @@ class MealPlanService:
             "fallback_used": True,
         }
 
-    def format_plan_created_message(self, plan):
+    def format_plan_created_message(self, plan, locale="zh"):
+        locale = _normalize_locale(locale)
         meal_lines = []
         for meal_key in ["breakfast", "lunch", "dinner"]:
             schedule = plan["meal_schedule"][meal_key]
-            meal_lines.append(
-                f"- {schedule['label']}: {schedule['meal_time']} 用餐，{schedule['push_time']} 推送"
-            )
+            meal_label = _meal_label_for_locale(meal_key, schedule, locale)
+            if locale == "en":
+                meal_lines.append(f"- {meal_label}: eat at {schedule['meal_time']}, push at {schedule['push_time']}")
+            else:
+                meal_lines.append(f"- {meal_label}: {schedule['meal_time']} 用餐，{schedule['push_time']} 推送")
 
         first_days = plan.get("days", [])[:3]
-        preview_lines = []
-        for day in first_days:
-            preview_lines.append(f"- {day['date']} | {day['theme']}")
+        preview_lines = [f"- {day['date']} | {_theme_name_for_locale(day, locale)}" for day in first_days]
 
         constraint_lines = list(plan.get("constraints", {}).get("notes", []))
         if not constraint_lines:
-            constraint_lines = ["- 当前按通用健康约束生成，后续可继续根据你的偏好微调。"]
-        else:
-            constraint_lines = [f"- {item}" for item in constraint_lines]
+            constraint_lines = ["当前按通用健康约束生成，后续可继续根据你的偏好微调。"]
+        constraint_lines = [f"- {_translate_constraint_note(item, locale)}" for item in constraint_lines]
+
+        if locale == "en":
+            return "\n".join(
+                [
+                    "**Meal Plan Created**",
+                    f"Goal: `{plan.get('goal_label_en') or plan['goal_label']}`",
+                    f"Period: `{plan['start_date']}` plus `{plan['duration_days']}` consecutive days",
+                    f"Strategy: {plan.get('summary_en') or plan['summary']}",
+                    "",
+                    "**Meal Push Schedule**",
+                    *meal_lines,
+                    "",
+                    "**Detected Health Constraints**",
+                    *constraint_lines,
+                    "",
+                    "**Preview of the First 3 Days**",
+                    *preview_lines,
+                    "",
+                    f"_{_recommendation_source_note_for_locale(plan.get('recommendation_source', 'unknown'), locale)}_",
+                ]
+            )
 
         return "\n".join(
             [
@@ -1406,14 +1857,28 @@ class MealPlanService:
                 "**前 3 天主题预览**",
                 *preview_lines,
                 "",
-                f"_{_recommendation_source_note(plan.get('recommendation_source', 'unknown'))}_",
+                f"_{_recommendation_source_note_for_locale(plan.get('recommendation_source', 'unknown'), locale)}_",
             ]
         )
 
-    def format_plan_status_message(self, plan):
+    def format_plan_status_message(self, plan, locale="zh"):
+        locale = _normalize_locale(locale)
         if not plan:
+            if locale == "en":
+                return "There is no active meal plan yet. You can say: I want to lose weight, give me a meal plan for the next month."
             return "当前还没有激活的饮食计划。你可以直接说：我想减肥，给我未来一个月的用餐计划。"
         sent_count = len(plan.get("sent_log", {}))
+        if locale == "en":
+            return "\n".join(
+                [
+                    "**Current Meal Plan**",
+                    f"Status: `{plan.get('status', 'unknown')}`",
+                    f"Goal: `{plan.get('goal_label_en') or plan.get('goal_label', '')}`",
+                    f"Start date: `{plan.get('start_date', '')}`",
+                    f"Meals already sent: `{sent_count}`",
+                    f"Recommendation source: `{_recommendation_source_label_for_locale(plan.get('recommendation_source', 'unknown'), locale)}`",
+                ]
+            )
         return "\n".join(
             [
                 "**当前饮食计划**",
@@ -1421,7 +1886,7 @@ class MealPlanService:
                 f"目标: `{plan.get('goal_label', '')}`",
                 f"开始日期: `{plan.get('start_date', '')}`",
                 f"已发送餐次: `{sent_count}`",
-                f"推荐来源: `{_recommendation_source_label(plan.get('recommendation_source', 'unknown'))}`",
+                f"推荐来源: `{_recommendation_source_label_for_locale(plan.get('recommendation_source', 'unknown'), locale)}`",
             ]
         )
 
@@ -1496,7 +1961,8 @@ class MealPlanService:
             return {"status": "success"}
         return {"status": "error", "msg": f"plan not found: {plan_id}"}
 
-    def format_push_message(self, push):
+    def format_push_message(self, push, locale="zh"):
+        locale = _normalize_locale(locale)
         day_plan = push["day_plan"]
         meal_spec = push["meal_spec"]
         candidates = push.get("display_candidates") or []
@@ -1504,66 +1970,121 @@ class MealPlanService:
         candidate_lines = []
         if candidates:
             for idx, item in enumerate(candidates, start=1):
-                candidate_lines.extend(
-                    [
-                        f"{idx}. **{item['item_name']}**",
-                        f"店铺：{item.get('store_name', '待手机美团确认')}",
-                        f"推荐理由：{item.get('reason', '整体更接近今天这顿的健康目标')}",
-                        f"价格：{item.get('price', '') or '待店内确认'}",
-                    ]
-                )
+                if locale == "en":
+                    candidate_lines.extend(
+                        [
+                            f"{idx}. **{item['item_name']}**",
+                            f"Store: {item.get('store_name', 'Pending phone Meituan confirmation')}",
+                            f"Why it fits: {_candidate_reason_for_locale(item, locale, '整体更接近今天这顿的健康目标', 'Overall it is closer to this meal target')}",
+                            f"Price: {item.get('price', '') or 'Pending in-store confirmation'}",
+                        ]
+                    )
+                else:
+                    candidate_lines.extend(
+                        [
+                            f"{idx}. **{item['item_name']}**",
+                            f"店铺：{item.get('store_name', '待手机美团确认')}",
+                            f"推荐理由：{item.get('reason', '整体更接近今天这顿的健康目标')}",
+                            f"价格：{item.get('price', '') or '待店内确认'}",
+                        ]
+                    )
         else:
-            candidate_lines.append("- 当前没有匹配到合适候选，建议按今天的目标关键词手动搜索。")
+            candidate_lines.append(
+                "- No strong candidate matched yet. Try searching manually with today's target keywords."
+                if locale == "en"
+                else "- 当前没有匹配到合适候选，建议按今天的目标关键词手动搜索。"
+            )
 
         cart_lines = []
         if cart_action.get("status") == "added":
             summary = cart_action.get("cart_summary", {})
-            cart_lines = [
-                "**已自动加入购物车**",
-                f"- 商家: {cart_action.get('store_name', '')}",
-                f"- 商品: {cart_action.get('item_name', '')}",
-                f"- 单价: {cart_action.get('item_price', '') or summary.get('total_price', '')}",
-            ]
+            if locale == "en":
+                cart_lines = [
+                    "**Added to Cart Automatically**",
+                    f"- Store: {cart_action.get('store_name', '')}",
+                    f"- Item: {cart_action.get('item_name', '')}",
+                    f"- Unit price: {cart_action.get('item_price', '') or summary.get('total_price', '')}",
+                ]
+            else:
+                cart_lines = [
+                    "**已自动加入购物车**",
+                    f"- 商家: {cart_action.get('store_name', '')}",
+                    f"- 商品: {cart_action.get('item_name', '')}",
+                    f"- 单价: {cart_action.get('item_price', '') or summary.get('total_price', '')}",
+                ]
             if summary.get("total_price"):
-                cart_lines.append(f"- 当前购物车合计: {summary['total_price']}")
+                cart_lines.append(f"- {'Current cart total' if locale == 'en' else '当前购物车合计'}: {summary['total_price']}")
             if summary.get("shortage"):
-                cart_lines.append(f"- 当前状态: {summary['shortage']}")
+                cart_lines.append(f"- {'Current status' if locale == 'en' else '当前状态'}: {summary['shortage']}")
             if summary.get("shipping_text"):
-                cart_lines.append(f"- 配送信息: {summary['shipping_text']}")
+                cart_lines.append(f"- {'Delivery info' if locale == 'en' else '配送信息'}: {summary['shipping_text']}")
             if summary.get("cart_cta"):
-                cart_lines.append(f"- 按钮状态: {summary['cart_cta']}")
-            cart_lines.append("- 你现在可以直接去手机美团里确认并手动支付。")
+                cart_lines.append(f"- {'Button state' if locale == 'en' else '按钮状态'}: {summary['cart_cta']}")
+            cart_lines.append(
+                "- You can now open Meituan on the phone to confirm and pay manually."
+                if locale == "en"
+                else "- 你现在可以直接去手机美团里确认并手动支付。"
+            )
         elif cart_action.get("status"):
-            cart_lines = [
-                "**购物车自动处理结果**",
-            ]
+            cart_lines = ["**Cart Automation Result**"] if locale == "en" else ["**购物车自动处理结果**"]
             if cart_action.get("store_name"):
-                cart_lines.append(f"- 店铺: {cart_action.get('store_name')}")
+                cart_lines.append(f"- {'Store' if locale == 'en' else '店铺'}: {cart_action.get('store_name')}")
             if cart_action.get("item_name"):
-                cart_lines.append(f"- 识别商品: {cart_action.get('item_name')}")
+                cart_lines.append(f"- {'Detected item' if locale == 'en' else '识别商品'}: {cart_action.get('item_name')}")
             if cart_action.get("item_price"):
-                cart_lines.append(f"- 识别价格: {cart_action.get('item_price')}")
+                cart_lines.append(f"- {'Detected price' if locale == 'en' else '识别价格'}: {cart_action.get('item_price')}")
             if cart_action.get("status") == "skipped_safety_check":
-                cart_lines.append("- 已为了安全起见跳过自动加购，你可以根据上面的候选自行确认。")
+                cart_lines.append(
+                    "- Auto add-to-cart was skipped for safety. You can confirm manually from the candidates above."
+                    if locale == "en"
+                    else "- 已为了安全起见跳过自动加购，你可以根据上面的候选自行确认。"
+                )
             if cart_action.get("status") == "needs_spec_selection":
-                cart_lines.append("- 当前商品需要手动选择规格，我已经帮你定位到店铺页。")
-                cart_lines.append("- 你现在可以直接在手机美团里点“选规格”，确认后再支付。")
+                cart_lines.append(
+                    "- This item has already reached the ordering step and now needs manual spec or combo selection."
+                    if locale == "en"
+                    else "- 当前商品已经进入点餐步骤，但还需要手动选择规格/套餐。"
+                )
+                cart_lines.append(
+                    "- The demo has opened the spec selector when possible. You can confirm the choice and continue ordering manually."
+                    if locale == "en"
+                    else "- 如果页面已弹出选规格/选套餐面板，你现在可以直接确认后继续下单。"
+                )
             if cart_action.get("status") == "no_addable_item_found":
-                cart_lines.append("- 已打开推荐店铺，但当前没稳定定位到可直接加购按钮。")
-                cart_lines.append("- 你现在可以直接在手机美团里查看该店铺并手动选择这一餐。")
+                cart_lines.append(
+                    "- The recommended store page was opened, but the demo could not reliably find an add-to-cart button."
+                    if locale == "en"
+                    else "- 已打开推荐店铺，但当前没稳定定位到可直接加购按钮。"
+                )
+                cart_lines.append(
+                    "- You can now inspect the store directly in Meituan and choose this meal manually."
+                    if locale == "en"
+                    else "- 你现在可以直接在手机美团里查看该店铺并手动选择这一餐。"
+                )
             if cart_action.get("status") == "no_result_card_found":
-                cart_lines.append("- 当前没有稳定解析到商家卡片，建议你按上面的候选词手动搜索一次。")
+                cart_lines.append(
+                    "- The demo could not reliably parse a store card this time. Try one manual search with the suggested keywords above."
+                    if locale == "en"
+                    else "- 当前没有稳定解析到商家卡片，建议你按上面的候选词手动搜索一次。"
+                )
+
+        meal_label = push.get("meal_label_en") or push.get("meal_label", "")
+        if locale != "en":
+            meal_label = push.get("meal_label", meal_label)
+        theme_name = _theme_name_for_locale(day_plan, locale)
+        goal_note = _goal_note_for_locale(meal_spec, locale)
+        query_display = _query_for_locale(meal_spec, locale)
 
         return "\n".join(
             [
-                f"**{push['meal_label']}推荐提醒**",
-                f"日期: `{push['date']}`",
-                f"建议用餐时间: `{push['meal_time']}`",
-                f"今日主题: `{day_plan['theme']}`",
-                f"这一顿目标: {meal_spec['goal_note']}",
-                f"建议搜索词: `{meal_spec['query']}`",
+                f"**{meal_label} Recommendation Reminder**" if locale == "en" else f"**{meal_label}推荐提醒**",
+                f"Date: `{push['date']}`" if locale == "en" else f"日期: `{push['date']}`",
+                f"Suggested meal time: `{push['meal_time']}`" if locale == "en" else f"建议用餐时间: `{push['meal_time']}`",
+                f"Today's theme: `{theme_name}`" if locale == "en" else f"今日主题: `{theme_name}`",
+                f"This meal is aiming for: {goal_note}" if locale == "en" else f"这一顿目标: {goal_note}",
+                f"Suggested search: `{query_display}`" if locale == "en" else f"建议搜索词: `{query_display}`",
                 "",
-                "**候选餐**",
+                "**Meal Candidates**" if locale == "en" else "**候选餐**",
                 *candidate_lines,
                 "",
                 *cart_lines,

--- a/memory/L3_sops/meituan_food_analysis_sop.md
+++ b/memory/L3_sops/meituan_food_analysis_sop.md
@@ -27,6 +27,16 @@ phone_control(action="launch_app", app="美团")
   - 原因：该包名的默认Activity可能不存在或需要额外参数
   - 实践经验：多次测试失败，报错"MainActivity not found"
 
+**成功案例：**
+上次成功启动使用的是桌面点击法（因为launch_app失败），但推荐先尝试 `app="美团"` 参数，这是最简洁的方式。
+
+**备选方法：桌面点击（launch_app失败时）**
+```python
+1. phone_control(action="press_key", key="home")  # 返回桌面
+2. phone_screen_analyze(question="桌面上美团或美团外卖图标的坐标？")
+3. phone_control(action="tap", x=坐标x, y=坐标y)
+```
+
 等待2秒让App加载。
 
 ### 3. 进入订单列表
@@ -41,10 +51,9 @@ phone_screen_analyze(question="当前是什么页面？如何进入订单列表�
 - 美团主App：进入"我的" → "全部订单"
 
 **关键原则：不要硬编码坐标！**
-1. 优先使用原子动作：`phone_control(action="tap_keyword_confirm", keyword="订单")` 或 `keyword="全部订单"`（内部已封装 `ui_dump -> 点击 -> 确认`）
-2. 若原子动作返回未命中/不确定，再用 `ui_dump(keyword="订单", clickable_only=true)` 手动定位并点击
-3. 只有在 `ui_dump` 无法定位时，才使用 `phone_screen_analyze` 视觉兜底
-4. 点击后用 `phone_screen_analyze` 做一次最终页面确认（是否已进入订单列表）
+1. 先用 `ui_dump(keyword="订单")` 尝试找坐标
+2. 找不到就用 `phone_screen_analyze` 识别位置
+3. 点击后用 `phone_screen_analyze` 确认是否进入订单页
 
 ### 4. 收集订单信息
 
@@ -145,7 +154,7 @@ phone_screen_analyze(question="列出当前屏幕所有订单：时间、店名�
 - 不要重复截图同一屏幕
 
 ### 🔧 错误处理
-- **启动失败**：改用包名重试（`app="com.sankuai.meituan"`），并用 `current_app` 检查前台应用
+- **启动失败**：改用桌面点击法
 - **找不到按钮**：用 `phone_screen_analyze` 动态定位
 - **App闪退**：重新启动，多次失败询问用户
 - **误触支付**：立即 `press_key(back)` 返回

--- a/memory/L3_sops/phone_control_sop.md
+++ b/memory/L3_sops/phone_control_sop.md
@@ -37,31 +37,25 @@ phone_control(action="check_connection")  # 仅任务开始首次执行；后续
    
 2. **截图分析**（视觉理解，适合复杂界面）：
    ```
-   phone_screen_analyze(question="当前页面结构和可操作区域是什么？")
+   phone_control(action="screenshot_analyze", question="当前页面结构和可操作区域是什么？")
    ```
    截取屏幕并通过 LLM 视觉能力分析。
 
 ### Step 3: 决策下一步操作
 根据感知结果，决定：
-- 需要点击哪个元素？→ **优先原子动作** `tap_keyword_confirm`（内部封装“找元素+点+确认”）
+- 需要点击哪个元素？→ 使用元素的 (cx, cy) 坐标
 - 需要滑动查看更多？→ scroll_down / scroll_up
 - 需要输入文字？→ input_text
 - 需要返回？→ press_key(back)
 
 ### Step 4: 执行操作
 ```
-phone_control(action="tap_keyword_confirm", keyword="订单", confirm_keyword="订单列表")  # 优先：关键词点击+确认
 phone_control(action="tap", x=540, y=1200)        # 点击
 phone_control(action="swipe", x1=540, y1=1600, x2=540, y2=400)  # 滑动
 phone_control(action="input_text", text="示例输入")    # 输入
 phone_control(action="press_key", key="back")       # 返回
 phone_control(action="launch_app", app="目标应用名或包名")  # 启动App
 ```
-**推荐点击顺序（P0）**：
-1. `phone_control(action="tap_keyword_confirm", keyword="目标关键词")`
-2. 若返回未命中/不确定：`phone_control(action="ui_dump", keyword="目标关键词", clickable_only=true)` 后手动 `tap`
-3. 若 `ui_dump` 仍无法定位，再用 `phone_screen_analyze` 做视觉兜底
-
 **启动失败时**（以 Agent 自行匹配为准，工具只做兜底）：
 1. **主流程**：工具仅返回本机已安装应用列表（完整或前 N 个）。**由 Agent 根据用户描述与该列表自行做关键词/语义匹配**，选出最可能的目标包名并用 `launch_app(app="包名")` 重试。不依赖代码内预置关键词表。
 2. **兜底**：若 Agent 判断列表中**无与用户描述相关的包**，则停止任务并向用户说明，或建议用户说出具体应用名称。勿把预置名称（如「华为健康」）当成本机已安装。

--- a/memory/L3_sops/xiaomi_health_analysis_sop.md
+++ b/memory/L3_sops/xiaomi_health_analysis_sop.md
@@ -91,7 +91,6 @@
 - 成本更低
 - 文字更稳定
 - 便于后续复核与自动抽取
-- 可优先使用 `phone_control(action="tap_keyword_confirm", keyword="压力", confirm_keyword="周")` 这类原子动作，减少「找元素+点击+确认」的多轮调用
 
 ### 策略 2：图表场景切视觉分析
 以下情况应切到 `phone_screen_analyze`：
@@ -136,11 +135,12 @@
 
 ## 回退策略
 按以下顺序回退：
-1. `phone_control(action="tap_keyword_confirm", keyword="压力")`
-2. 若未命中，`scroll_down` 后再次 `tap_keyword_confirm(keyword="压力")`
-3. 进入详情后，必要时 `tap_keyword_confirm(keyword="周", confirm_keyword="周")`
-4. 全量 `ui_dump`
-5. 若仍不完整，使用 `phone_screen_analyze`
+1. `ui_dump(keyword="压力")`
+2. `scroll_down` 后再次 `ui_dump`
+3. 点击压力卡片进入详情
+4. 切换“周”
+5. 全量 `ui_dump`
+6. 若仍不完整，使用 `phone_screen_analyze`
 
 若仍失败，再考虑：
 - 查看当前前台应用是否正确：

--- a/seda_main.py
+++ b/seda_main.py
@@ -375,36 +375,8 @@ def get_system_prompt(autonomous=False, user_query=""):
         prompt += "它们依赖浏览器连接，在后台运行时会导致卡死。\n"
 
     prompt += f"\nToday: {time.strftime('%Y-%m-%d %a')}\n"
-    prompt += _build_output_language_policy(user_query)
     prompt += get_global_memory(user_query=user_query)
     return prompt
-
-
-def _build_output_language_policy(user_query: str) -> str:
-    """
-    根据用户本轮输入附加输出语言约束。
-    目标：英文输入时优先英文回答；中文输入时优先中文回答；混合/不确定则保持默认。
-    """
-    q = (user_query or "").strip()
-    if not q:
-        return ""
-
-    cjk_count = len(re.findall(r"[\u4e00-\u9fff]", q))
-    en_word_count = len(re.findall(r"\b[a-zA-Z]{2,}\b", q))
-
-    if en_word_count >= 3 and en_word_count > cjk_count:
-        return (
-            "\n[Output Language Policy]\n"
-            "- The user's latest message is primarily in English.\n"
-            "- Respond in English by default, unless the user explicitly asks for another language.\n"
-        )
-    if cjk_count >= 2 and cjk_count >= en_word_count:
-        return (
-            "\n[输出语言策略]\n"
-            "- 用户本轮消息以中文为主。\n"
-            "- 默认使用中文回答；除非用户明确要求使用其他语言。\n"
-        )
-    return ""
 
 
 def _strip_autonomous_section(text):

--- a/stapp.py
+++ b/stapp.py
@@ -505,7 +505,7 @@ if st.session_state.get("_show_health_plan_form", False):
         if run_clicked and selected_ids:
             st.session_state["_show_health_plan_form"] = False
             _prompt = och.build_one_click_analysis_prompt(
-                int(time_window), selected_ids, output_language=_loc()
+                int(time_window), selected_ids
             )
             _task_names = [
                 subtask_display_name_desc(row, _hl)[0]
@@ -526,6 +526,8 @@ if st.session_state.get("_pending_health_prompt"):
     _display = st.session_state.pop(
         "_pending_health_display", t("one_click_fallback_display")
     )
+    with st.chat_message("user"):
+        st.markdown(_display)
     with st.chat_message("assistant"):
         message_placeholder = st.empty()
         response = ""

--- a/tools/one_click_health.py
+++ b/tools/one_click_health.py
@@ -151,33 +151,17 @@ def load_subtasks_from_main_sop(project_root: Optional[Path] = None) -> list[dic
     return list(DEFAULT_SUBTASKS)
 
 
-def build_one_click_analysis_prompt(
-    time_window_days: int, selected_task_ids: list, output_language: str = "auto"
-) -> str:
+def build_one_click_analysis_prompt(time_window_days: int, selected_task_ids: list) -> str:
     tasks_str = json.dumps(selected_task_ids, ensure_ascii=False)
-    lang = (output_language or "auto").strip().lower()
-    if lang not in {"zh", "en", "auto"}:
-        lang = "auto"
-    lang_line = (
-        "请使用中文输出最终综合报告。"
-        if lang == "zh"
-        else (
-            "Please output the final integrated report in English."
-            if lang == "en"
-            else "最终综合报告语言跟随用户本轮语言偏好。"
-        )
-    )
     return (
         f"{PROMPT_TAG_HEALTH_ANALYSIS}\n"
         f"mode={MODE_HEALTH_ANALYSIS}\n"
         f"time_window_days={time_window_days}\n"
         f"tasks={tasks_str}\n"
-        f"output_language={lang}\n"
         f"output_format=integrated_report_v1\n\n"
         f"请先读取 {MAIN_SOP_RELPATH} 获取执行规范，"
         f"然后按tasks列表顺序串行执行各子任务SOP，最后按SOP中定义的综合报告模板输出完整报告。\n"
-        f"分析时间范围：最近{time_window_days}天。\n"
-        f"{lang_line}"
+        f"分析时间范围：最近{time_window_days}天。"
     )
 
 

--- a/ukb_handler.py
+++ b/ukb_handler.py
@@ -1645,7 +1645,7 @@ class UKBAgentHandler(GenericAgentHandler):
                 time.sleep(0.5)
                 return StepOutcome(
                     data={"status": "ok" if ok else "error", "msg": msg},
-                    next_prompt=self._get_anchor_prompt() + f"\n[点击操作] 已点击坐标 ({x}, {y})。\n请先用 ui_dump 确认结果；仅当 ui_dump 无法判断时再使用 phone_screen_analyze。"
+                    next_prompt=self._get_anchor_prompt() + f"\n[点击操作] 已点击坐标 ({x}, {y})。\n建议用 ui_dump 或 phone_screen_analyze 确认操作结果。"
                 )
 
             elif action == "swipe":
@@ -1695,7 +1695,7 @@ class UKBAgentHandler(GenericAgentHandler):
                 ok, msg = launch_app(app)
                 time.sleep(2)
                 if ok:
-                    next_prompt = self._get_anchor_prompt() + f"\n[启动App] {msg}\n等待2秒后，优先用 ui_dump 检查页面；仅在 ui_dump 信息不足时再用 phone_screen_analyze。"
+                    next_prompt = self._get_anchor_prompt() + f"\n[启动App] {msg}\n等待2秒后，建议用 ui_dump 或 phone_screen_analyze 查看App界面。"
                 else:
                     next_prompt = self._get_anchor_prompt() + f"\n[启动App 失败] {msg}\n请根据用户描述与上述本机已安装列表自行做关键词/语义匹配选包重试；若列表中无相关包则停止任务并向用户说明或建议其说出具体应用名称。"
                 return StepOutcome(
@@ -1715,114 +1715,12 @@ class UKBAgentHandler(GenericAgentHandler):
                     next_prompt=self._get_anchor_prompt() + f"\n[UI元素列表]\n{full_summary}\n\n根据UI元素决定下一步操作（点击、滑动等）。"
                 )
 
-            elif action == "tap_keyword_confirm":
-                keyword = str(args.get("keyword", "") or "").strip()
-                if not keyword:
-                    return StepOutcome(
-                        data={"status": "error", "msg": "tap_keyword_confirm 需要 keyword 参数"},
-                        next_prompt=self._get_anchor_prompt() + "\n[错误] tap_keyword_confirm 需要提供 keyword 参数。"
-                    )
-                confirm_keyword = str(args.get("confirm_keyword", "") or "").strip()
-                wait_ms = int(args.get("wait_ms", 1200) or 1200)
-                clickable_only = bool(args.get("clickable_only", False))
-
-                before_app = get_current_app()
-                before_nodes, _ = ui_dump(keyword, clickable_only)
-                fallback_used = False
-                # 常见场景：文本节点不可点击、父容器可点击。若仅查 clickable 节点失败，自动回退全量检索一次。
-                if not before_nodes and clickable_only:
-                    before_nodes, _ = ui_dump(keyword, False)
-                    fallback_used = bool(before_nodes)
-                if not before_nodes:
-                    return StepOutcome(
-                        data={
-                            "status": "error",
-                            "msg": f"未找到关键词元素: {keyword}",
-                            "keyword": keyword,
-                            "clickable_only": clickable_only,
-                            "fallback_used": fallback_used,
-                        },
-                        next_prompt=self._get_anchor_prompt() + (
-                            f"\n[点击失败] 未找到关键词「{keyword}」对应元素。"
-                            + ("\n已自动回退到 clickable_only=false 重试，仍未命中。" if clickable_only else "")
-                            + "\n建议先用 ui_dump(clickable_only=false) 查看全量结构；仅在仍无法定位时再用 phone_screen_analyze。"
-                        )
-                    )
-
-                # 优先可点击节点；若都不可点击，退化到首个匹配节点中心点点击
-                target = next((n for n in before_nodes if n.get("clickable")), before_nodes[0])
-                x, y = int(target.get("cx", 0) or 0), int(target.get("cy", 0) or 0)
-                if x <= 0 or y <= 0:
-                    return StepOutcome(
-                        data={"status": "error", "msg": "目标元素缺少可用坐标", "target": target},
-                        next_prompt=self._get_anchor_prompt() + f"\n[点击失败] 关键词「{keyword}」已命中，但元素缺少可用坐标。可改用 phone_screen_analyze 识别。"
-                    )
-
-                ok, msg = tap(x, y)
-                if not ok:
-                    return StepOutcome(
-                        data={"status": "error", "msg": msg, "keyword": keyword, "target": target},
-                        next_prompt=self._get_anchor_prompt() + f"\n[点击失败] 关键词「{keyword}」命中后点击失败: {msg}"
-                    )
-
-                time.sleep(max(wait_ms, 200) / 1000.0)
-                after_app = get_current_app()
-                check_keyword = confirm_keyword or keyword
-                after_nodes, _ = ui_dump(check_keyword, False)
-
-                app_changed = (
-                    before_app.get("package") != after_app.get("package")
-                    or before_app.get("activity") != after_app.get("activity")
-                )
-                confirm_hit = bool(after_nodes) if confirm_keyword else False
-                keyword_changed = len(after_nodes) != len(before_nodes)
-                confirmed = app_changed or confirm_hit or keyword_changed
-
-                confirm_reason = []
-                if app_changed:
-                    confirm_reason.append("app/activity changed")
-                if confirm_hit:
-                    confirm_reason.append(f"found confirm_keyword={check_keyword}")
-                if keyword_changed:
-                    confirm_reason.append("keyword nodes count changed")
-                if not confirm_reason:
-                    confirm_reason.append("state unchanged; need visual verify")
-
-                status = "ok" if confirmed else "warning"
-                needs_visual_verify = not confirmed
-                return StepOutcome(
-                    data={
-                        "status": status,
-                        "msg": f"tap_keyword_confirm({keyword})",
-                        "confirmed": confirmed,
-                        "needs_visual_verify": needs_visual_verify,
-                        "confirm_reason": ", ".join(confirm_reason),
-                        "tap_point": {"x": x, "y": y},
-                        "target": target,
-                        "before_app": before_app,
-                        "after_app": after_app,
-                        "before_match_count": len(before_nodes),
-                        "after_match_count": len(after_nodes),
-                        "fallback_used": fallback_used,
-                    },
-                    next_prompt=self._get_anchor_prompt() + (
-                        f"\n[关键词点击] 已尝试点击「{keyword}」@({x},{y})。"
-                        + ("\n说明: 初次 clickable_only=true 未命中，已自动回退全量检索并命中。" if fallback_used else "")
-                        + f"\n确认结果: {'成功' if confirmed else '不确定'}（{', '.join(confirm_reason)}）。"
-                        + (
-                            f"\n已命中确认关键词「{check_keyword}」。可继续下一步，通常无需视觉确认。"
-                            if confirmed
-                            else "\n建议先做一次 ui_dump(可不带关键词) 再确认；仅当仍不确定时使用 phone_screen_analyze。"
-                        )
-                    )
-                )
-
             elif action == "scroll_down":
                 ok, msg = scroll_down()
                 time.sleep(0.5)
                 return StepOutcome(
                     data={"status": "ok" if ok else "error", "msg": msg},
-                    next_prompt=self._get_anchor_prompt() + "\n[滚动] 已向下滚动一屏。请优先用 ui_dump 查看新内容；仅在文本信息不足时再用 phone_screen_analyze。"
+                    next_prompt=self._get_anchor_prompt() + "\n[滚动] 已向下滚动一屏。建议用 ui_dump 查看新内容。"
                 )
 
             elif action == "scroll_up":
@@ -1830,7 +1728,7 @@ class UKBAgentHandler(GenericAgentHandler):
                 time.sleep(0.5)
                 return StepOutcome(
                     data={"status": "ok" if ok else "error", "msg": msg},
-                    next_prompt=self._get_anchor_prompt() + "\n[滚动] 已向上滚动一屏。请优先用 ui_dump 查看新内容；仅在文本信息不足时再用 phone_screen_analyze。"
+                    next_prompt=self._get_anchor_prompt() + "\n[滚动] 已向上滚动一屏。建议用 ui_dump 查看新内容。"
                 )
 
             elif action == "current_app":
@@ -1856,7 +1754,7 @@ class UKBAgentHandler(GenericAgentHandler):
             else:
                 return StepOutcome(
                     data={"status": "error", "msg": f"未知操作: {action}"},
-                    next_prompt=self._get_anchor_prompt() + f"\n[错误] 未知操作: {action}。\n可用操作: check_connection, screenshot, tap, swipe, input_text, press_key, launch_app, ui_dump, tap_keyword_confirm, scroll_down, scroll_up, current_app, list_apps"
+                    next_prompt=self._get_anchor_prompt() + f"\n[错误] 未知操作: {action}。\n可用操作: check_connection, screenshot, tap, swipe, input_text, press_key, launch_app, ui_dump, scroll_down, scroll_up, current_app, list_apps"
                 )
         except Exception as e:
             return StepOutcome(


### PR DESCRIPTION
## Summary
- sync the current local HealthClaw workspace changes into a clean PR branch
- update cross-device demo and alert flow logic, including locale-aware demo content
- update meal-plan / Meituan phone flow logic and related docs/schemas
- keep the PR scoped to the current local changes only, without runtime artifacts

## Verification
- python3 tests/test_cross_device_server.py
- python3 tests/test_external_alert_server.py
- python3 tests/test_device_bindings.py
- python3 tests/test_meituan_phone_provider.py
- python3 tests/test_meal_plan_service.py
- python3 tests/test_one_click_health.py
